### PR TITLE
try more safe cut-node reductions, STC pass! bench: 2230601

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -407,9 +407,14 @@ int negamax(int alpha, int beta, int depth, board* position, time* time, bool cu
         // run quiescence search
         return quiescence(alpha, beta, position, score, time, improving);
 
+    bool moreSafeCutNodeReduction;
+    if (position->nmpNode && depth >= 3) {
+        moreSafeCutNodeReduction = true;
+    }
+
     // IIR by Ed Schroder (~15 Elo)
     if ((depth >= 4 && ttBound == hashFlagNone) || cutNode)
-        depth -= 1 + (cutNode);
+        depth -= 1 + (cutNode && !moreSafeCutNodeReduction);
 
     // increment nodes count
     searchNodes++;
@@ -508,6 +513,8 @@ int negamax(int alpha, int beta, int depth, board* position, time* time, bool cu
         // hash the side
         position->hashKey ^= sideKey;
 
+        position->nmpNode = true;
+
         int R = 3 + (int)(0.1875 * depth);
 
         /* search moves with reduced depth to find beta cutoffs
@@ -519,6 +526,8 @@ int negamax(int alpha, int beta, int depth, board* position, time* time, bool cu
 
         // decrement repetition index
         position->repetitionIndex--;
+
+        position->nmpNode = false;
 
         // restore board state
         takeBack(position, &copyPosition);

--- a/src/structs.h
+++ b/src/structs.h
@@ -35,6 +35,9 @@ typedef struct {
 
     double improvingRate[maxPly];
 
+    // null move pruning node
+    bool nmpNode;
+
     int followPv;
     int scorePv;
 


### PR DESCRIPTION
----------------------------------------------------------------
Elo   | 9.40 +- 6.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8098 W: 3112 L: 2893 D: 2093
Penta | [457, 762, 1495, 775, 560]
https://programcidusunur.pythonanywhere.com/test/262/
----------------------------------------------------------------