### PR TITLE
Add Post LMR History Reduction

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1273,7 +1273,9 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
 
             if (score > alpha && lmrReduction != 0) {
                 bool doDeeper = score > bestScore + DEEPER_LMR_MARGIN;
+                bool historyReduction = moveHistory / 16384;
                 new_depth += doDeeper;
+                new_depth -= historyReduction;
                 score = -negamax(-alpha - 1, -alpha, new_depth, pos, time, !cutNode);
             }
         }


### PR DESCRIPTION
-----------------------------------------------
Elo   | 4.31 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18788 W: 5291 L: 5058 D: 8439
Penta | [499, 2162, 3865, 2343, 525]
https://chess.n9x.co/test/1985/
-----------------------------------------------

bench: 6467386