### PR TITLE
Add LMR Depth To Quiet History Pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1078,7 +1078,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
                     continue;
                 }
                 // Quiet History Pruning
-                if (depth <= 4 && !in_check && moveHistory < depth * -2048) {
+                if (lmrDepth <= 4 && !in_check && moveHistory < lmrDepth * -2048) {
                     break;
                 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -1078,7 +1078,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
                     continue;
                 }
                 // Quiet History Pruning
-                if (lmrDepth <= 4 && !in_check && moveHistory < lmrDepth * -2048) {
+                if (lmrDepth <= 4 && !in_check && moveHistory < lmrDepth * lmrDepth * -2048) {
                     break;
                 }
 


### PR DESCRIPTION
----------------------------------------------------
Elo   | 7.86 +- 5.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7782 W: 2205 L: 2029 D: 3548
Penta | [182, 906, 1589, 982, 232]
https://chess.n9x.co/test/1987/
----------------------------------------------------