### PR TITLE
New TT Replacement Scheme

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -807,7 +807,7 @@ int quiescence(int alpha, int beta, board* position, time* time) {
 
 
     // store hash entry with the score equal to alpha
-    writeHashEntry(bestScore, bestMove, 0, hashFlag, tt_pv, position);
+    writeHashEntry(position->hashKey, bestScore, bestMove, 0, hashFlag, tt_pv, position);
 
     // node (move) fails low
     return bestScore;
@@ -1382,7 +1382,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
         }
 
         // store hash entry with the score equal to alpha
-        writeHashEntry(bestScore, bestMove, depth, hashFlag, tt_pv, pos);
+        writeHashEntry(pos->hashKey, bestScore, bestMove, depth, hashFlag, tt_pv, pos);
     }
     // node (move) fails low
     return bestScore;

--- a/src/table.c
+++ b/src/table.c
@@ -174,16 +174,16 @@ void prefetch_hash_entry(uint64_t hash_key) {
 }
 
 
-void writeHashEntry(int16_t score, int bestMove, uint8_t depth, uint8_t hashFlag, bool ttPv, board* position) {
+void writeHashEntry(uint64_t key, int16_t score, int bestMove, uint8_t depth, uint8_t hashFlag, bool ttPv, board* position) {
     // create a TT instance pointer to particular hash entry storing
     // the scoring data for the current board position if available
     tt *hashEntry = &hashTable[get_hash_index(position->hashKey)];
 
-    if (bestMove != 0 || hashEntry->hashKey != position->hashKey) {
+    if (bestMove != 0 || key != position->hashKey) {
         hashEntry->bestMove = bestMove;
     }
 
-    if (hashFlag == hashFlagExact || hashEntry->hashKey != position->hashKey || depth > hashEntry->depth) {
+    if (hashFlag == hashFlagExact || key != position->hashKey || depth > hashEntry->depth) {
         // store score independent from the actual path
         // from root node (position) to current node (position)
         if (score < -mateScore) score -= position->ply;

--- a/src/table.h
+++ b/src/table.h
@@ -33,7 +33,7 @@ U64 generateHashKey(board* position);
 uint64_t get_hash_index(uint64_t hash);
 uint32_t get_hash_low_bits(uint64_t hash);
 void prefetch_hash_entry(uint64_t hash_key);
-void writeHashEntry(int16_t score, int bestMove, uint8_t depth, uint8_t hashFlag, bool ttPv, board* position);
+void writeHashEntry(uint64_t key, int16_t score, int bestMove, uint8_t depth, uint8_t hashFlag, bool ttPv, board* position);
 int readHashEntry(board *position, int *move, int16_t *tt_score,
                   uint8_t *tt_depth, uint8_t *tt_flag, bool *tt_pv);
 U64 generatePawnKey(board* position);


### PR DESCRIPTION
-------------------------------------------------
Elo   | 4.03 +- 3.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20356 W: 5721 L: 5485 D: 9150
Penta | [504, 2412, 4154, 2560, 548]
https://chess.n9x.co/test/2014/
-------------------------------------------------
Elo   | 10.05 +- 5.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5220 W: 1346 L: 1195 D: 2679
Penta | [83, 581, 1150, 694, 102]
https://chess.n9x.co/test/2015/
-------------------------------------------------
bench: 13738491