### PR TITLE
Post LMR Shallower

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1262,7 +1262,6 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
 
         lmrReduction /= 1024;
 
-
         int reduced_depth = myMAX(1, myMIN(new_depth - lmrReduction, new_depth));
 
         if(moves_searched >= LMR_FULL_DEPTH_MOVES &&


### PR DESCRIPTION
---------------------------------------------------
Elo   | 3.39 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26558 W: 7145 L: 6886 D: 12527
Penta | [585, 3148, 5608, 3299, 639]
https://chess.n9x.co/test/2027/
---------------------------------------------------