### PR TITLE
Limit extensions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1092,7 +1092,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
         int extensions = 0;
 
         // Singular Extensions
-        if (!rootNode && depth >= SE_DEPTH + tt_pv && currentMove == tt_move && !pos->isSingularMove[pos->ply] &&
+        if (pos->ply < depth * 2 && !rootNode && depth >= SE_DEPTH + tt_pv && currentMove == tt_move && !pos->isSingularMove[pos->ply] &&
             tt_depth >= depth - SE_TT_DEPTH_SUBTRACTOR && tt_flag != hashFlagBeta &&
             abs(tt_score) < mateScore) {
             const int singularBeta = tt_score - depth * 5 / 8;


### PR DESCRIPTION
-------------------------------------------------------------------
Elo   | -0.26 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 34230 W: 8894 L: 8920 D: 16416
Penta | [742, 4197, 7290, 4117, 769]
https://chess.n9x.co/test/2117/
-------------------------------------------------------------------