### PR TITLE
Tweak lmr depth with move history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1059,7 +1059,9 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
         int moveHistory = notTactical ? quietHistory[pos->side][getMoveSource(currentMove)][getMoveTarget(currentMove)] +
                 getContinuationHistoryScore(pos, 1, currentMove) + getContinuationHistoryScore(pos, 4, currentMove): 0;
 
-        int lmrDepth = myMAX(0, depth - getLmrReduction(depth, legal_moves, notTactical));
+        int lmrDepth = myMAX(0, depth - getLmrReduction(depth, legal_moves, notTactical) + moveHistory / 8192);
+
+
 
         bool isNotMated = bestScore > -mateScore;
 


### PR DESCRIPTION
------------------------------------------------------
Elo   | 6.81 +- 4.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9078 W: 2489 L: 2311 D: 4278
Penta | [194, 1066, 1866, 1194, 219]
https://chess.n9x.co/test/2181/
------------------------------------------------------