### PR TITLE
Don't create major correction history key from scratch

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -433,7 +433,7 @@ void updateMinorCorrectionHistory(board *position, const int depth, const int di
 }
 
 void updateMajorCorrectionHistory(board *position, const int depth, const int diff) {
-    U64 majorKey = generateMajorKey(position);
+    U64 majorKey = position->majorKey;
 
     int entry = MAJOR_CORRECTION_HISTORY[position->side][majorKey % CORRHIST_SIZE];
 


### PR DESCRIPTION
-----------------------------------------------------
Elo   | 0.45 +- 2.26 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | -3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 39908 W: 11349 L: 11297 D: 17262
Penta | [1014, 4674, 8530, 4718, 1018]
https://chess.n9x.co/test/2217/
-----------------------------------------------------
It should have been a non-reg test, but it doesn't matter.