### PR TITLE
Use tt adjusted eval instead of static eval to better evaluation

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -976,7 +976,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
     // Null Move Pruning
     if (!pos->isSingularMove[pos->ply] && !pvNode &&
         depth >= NMP_DEPTH && !in_check && !rootNode &&
-            static_eval >= beta &&
+            ttAdjustedEval >= beta &&
             pos->ply >= pos->nmpPly &&
             !justPawns(pos)) {
         struct copyposition copyPosition;
@@ -1005,7 +1005,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
 
         int R = NMP_BASE_REDUCTION + depth / NMP_REDUCTION_DEPTH_DIVISOR;
 
-        R += myMIN((static_eval - beta) / NMP_EVAL_DIVISOR, 3);
+        R += myMIN((ttAdjustedEval - beta) / NMP_EVAL_DIVISOR, 3);
 
         pos->move[myMIN(pos->ply, maxPly - 1)] = 0;
         pos->piece[myMIN(pos->ply, maxPly - 1)] = 0;


### PR DESCRIPTION
------------------------------------------------
Elo   | 7.04 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8586 W: 2317 L: 2143 D: 4126
Penta | [173, 989, 1846, 1061, 224]
https://chess.n9x.co/test/2437/
------------------------------------------------

bench: 8339846