### PR TITLE
Tweak futility pruning margin with move history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1111,21 +1111,21 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
 
         if (!rootNode && notTactical && isNotMated) {
 
-                int lmpThreshold = (LMP_BASE + LMP_MULTIPLIER * lmrDepth * lmrDepth) / (2 - improving);
+            int lmpThreshold = (LMP_BASE + LMP_MULTIPLIER * lmrDepth * lmrDepth) / (2 - improving);
 
-                // Late Move Pruning
-                if (legal_moves>= lmpThreshold) {
-                    continue;
-                }
+            // Late Move Pruning
+            if (legal_moves>= lmpThreshold) {
+                continue;
+            }
 
-                // Futility Pruning
-                if (lmrDepth <= FP_DEPTH && !pvNode && !in_check && (static_eval + FUTILITY_PRUNING_OFFSET[clamp(lmrDepth, 1, 5)]) + FP_MARGIN * lmrDepth <= alpha) {
-                    continue;
-                }
-                // Quiet History Pruning
-                if (lmrDepth <= 4 && !in_check && moveHistory < lmrDepth * lmrDepth * -2048) {
-                    break;
-                }
+            // Futility Pruning
+            if (lmrDepth <= FP_DEPTH && !pvNode && !in_check && (static_eval + FUTILITY_PRUNING_OFFSET[clamp(lmrDepth, 1, 5)]) + FP_MARGIN * lmrDepth + moveHistory / 32 <= alpha) {
+                continue;
+            }
+            // Quiet History Pruning
+            if (lmrDepth <= 4 && !in_check && moveHistory < lmrDepth * lmrDepth * -2048) {
+                break;
+            }
 
         }
 


### PR DESCRIPTION
----------------------------------------------------------
Elo   | 5.64 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11696 W: 3149 L: 2959 D: 5588
Penta | [226, 1388, 2483, 1472, 279]
https://chess.n9x.co/test/2877/
----------------------------------------------------------

bench: 9083711