### PR TITLE
Shrink Pawn History

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -13,7 +13,7 @@ int rootHistory[2][64][64];
 // continuationHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
 int continuationHistory[12][64][12][64];
 // pawnHistory [pawnKey][piece][to]
-int pawnHistory[32768][12][64];
+int16_t pawnHistory[2048][12][64];
 
 int getHistoryBonus(int depth) {
     return myMIN(10 + 200 * depth, 4096);
@@ -71,9 +71,9 @@ void updatePawnHistory(board *pos, int bestMove, int depth, moves *badQuiets) {
     int to = getMoveTarget(bestMove);
 
     int bonus = getHistoryBonus(depth);
-    int score = pawnHistory[pos->pawnKey % 32767][pos->mailbox[from]][to];
+    int score = pawnHistory[pos->pawnKey % 2048][pos->mailbox[from]][to];
 
-    pawnHistory[pos->pawnKey % 32767][pos->mailbox[from]][to] += scaledBonus(score, bonus, maxPawnHistory);
+    pawnHistory[pos->pawnKey % 2048][pos->mailbox[from]][to] += scaledBonus(score, bonus, maxPawnHistory);
 
     for (int index = 0; index < badQuiets->count; index++) {
         if (badQuiets->moves[index] == bestMove) continue;
@@ -81,7 +81,7 @@ void updatePawnHistory(board *pos, int bestMove, int depth, moves *badQuiets) {
         int badQuietFrom = getMoveSource(badQuiets->moves[index]);
         int badQuietTo = getMoveTarget(badQuiets->moves[index]);
 
-        pawnHistory[pos->pawnKey % 32767][pos->mailbox[badQuietFrom]][badQuietTo] += scaledBonus(score, -bonus, maxPawnHistory);
+        pawnHistory[pos->pawnKey % 2048][pos->mailbox[badQuietFrom]][badQuietTo] += scaledBonus(score, -bonus, maxPawnHistory);
     }
 
 

--- a/src/history.h
+++ b/src/history.h
@@ -29,7 +29,7 @@ extern int rootHistory[2][64][64];
 // continuationHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
 extern int continuationHistory[12][64][12][64];
 // pawnHistory [pawnKey][piece][to]
-extern int pawnHistory[32768][12][64];
+extern int16_t pawnHistory[2048][12][64];
 
 
 int scaledBonus(int score, int bonus, int gravity);

--- a/src/search.c
+++ b/src/search.c
@@ -250,7 +250,7 @@ int scoreMove(int move, board* position) {
                 getContinuationHistoryScore(position, 1, move) +
                     getContinuationHistoryScore(position, 2, move) +
                         getContinuationHistoryScore(position, 4, move) +
-                            pawnHistory[position->pawnKey % 32767][position->mailbox[getMoveSource(move)]][getMoveTarget(move)] +
+                            pawnHistory[position->pawnKey % 2048][position->mailbox[getMoveSource(move)]][getMoveTarget(move)] +
                (position->ply == 0 * rootHistory[position->side][getMoveSource(move)][getMoveTarget(move)] * 4);
     }
     return 0;


### PR DESCRIPTION
-------------------------------------------------------
Elo   | 9.15 +- 6.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 4290 W: 1158 L: 1045 D: 2087
Penta | [78, 496, 912, 553, 106]
https://chess.n9x.co/test/3431/
-------------------------------------------------------

bench: 8454740