### PR TITLE
Do more correction history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -410,7 +410,7 @@ void updatePawnCorrectionHistory(board *position, const int depth, const int dif
     int entry = PAWN_CORRECTION_HISTORY[position->side][pawnKey % CORRHIST_SIZE];
 
     const int scaledDiff = diff * CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
 
     entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
     entry = clamp(entry, -CORRHIST_MAX, CORRHIST_MAX);
@@ -424,7 +424,7 @@ void updateMinorCorrectionHistory(board *position, const int depth, const int di
     int entry = MINOR_CORRECTION_HISTORY[position->side][minorKey % CORRHIST_SIZE];
 
     const int scaledDiff = diff * CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
 
     entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
     entry = clamp(entry, -CORRHIST_MAX, CORRHIST_MAX);
@@ -438,7 +438,7 @@ void updateMajorCorrectionHistory(board *position, const int depth, const int di
     int entry = MAJOR_CORRECTION_HISTORY[position->side][majorKey % CORRHIST_SIZE];
 
     const int scaledDiff = diff * CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
 
     entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
     entry = clamp(entry, -CORRHIST_MAX, CORRHIST_MAX);
@@ -451,7 +451,7 @@ void update_non_pawn_corrhist(board *position, const int depth, const int diff) 
     U64 blackKey = position->blackNonPawnKey;
 
     const int scaledDiff = diff * CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
 
     int whiteEntry = NON_PAWN_CORRECTION_HISTORY[white][position->side][whiteKey % CORRHIST_SIZE];
 


### PR DESCRIPTION
-----------------------------------------------------
Elo   | 8.82 +- 5.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6498 W: 1814 L: 1649 D: 3035
Penta | [137, 741, 1352, 858, 161]
https://rektdie.pythonanywhere.com/test/590/
-----------------------------------------------------

bench: 8701440