### PR TITLE
Reduce even less if our current node is principle variation node

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1297,7 +1297,7 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
 
         // Reduce Less
         if (tt_pv) {
-            lmrReduction -= TT_PV_LMR_SCALER;
+            lmrReduction -= TT_PV_LMR_SCALER + (512 * pvNode);
         }
 
         lmrReduction /= 1024;


### PR DESCRIPTION
---------------------------------------------------
Elo   | 3.50 +- 2.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26374 W: 7323 L: 7057 D: 11994
Penta | [647, 3100, 5486, 3248, 706]
https://rektdie.pythonanywhere.com/test/607/
---------------------------------------------------

bench: 9631161