### PR TITLE
New experiment successfull with one shot! Add Corrplexity Extension

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -965,6 +965,11 @@ int negamax(int alpha, int beta, int depth, board* pos, time* time, bool cutNode
         ttAdjustedEval = tt_score;
     }
 
+    // Corrplexity Extension
+    if (corrplexity && ttAdjustedEval != static_eval && (tt_move && tt_hit)) {
+        depth++;
+    }
+
     improving |= pos->staticEval[pos->ply] >= beta + 100;
 
     uint16_t rfpMargin = improving ? RFP_IMPROVING_MARGIN * (depth - 1) : RFP_MARGIN * depth;


### PR DESCRIPTION
-----------------------------------------------------
Elo   | -2.28 +- 6.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.33 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5484 W: 1504 L: 1540 D: 2440
Penta | [168, 653, 1109, 671, 141]
https://rektdie.pythonanywhere.com/test/705/
-----------------------------------------------------
Elo   | 9.15 +- 5.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5622 W: 1445 L: 1297 D: 2880
Penta | [67, 653, 1246, 755, 90]
https://rektdie.pythonanywhere.com/test/707/
-----------------------------------------------------

bench: 27135051