### PR TITLE
Add 50 Move Rule Scaling

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -462,7 +462,9 @@ void update_non_pawn_corrhist(board *position, const int depth, const int diff) 
     NON_PAWN_CORRECTION_HISTORY[black][position->side][blackKey % CORRHIST_SIZE] = blackEntry;
 }
 
-int adjustEvalWithCorrectionHistory(board *position, int rawEval) {    
+int adjustEvalWithCorrectionHistory(board *position, int rawEval) {   
+    rawEval = rawEval * (300 - position->fifty) / 300;
+    
     U64 pawnKey = position->pawnKey;
     U64 minorKey = position->minorKey;
     U64 majorKey = position->majorKey;


### PR DESCRIPTION
-------------------------------------------
Elo   | 0.38 +- 2.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 22968 W: 5751 L: 5726 D: 11491
Penta | [392, 2794, 5096, 2801, 401]
https://rektdie.pythonanywhere.com/test/724/
-------------------------------------------

bench: 45655311