### PR TITLE
if our tt was pv and we are improving then reduce less

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1308,7 +1308,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
 
         // Reduce Less
         if (tt_pv) {
-            lmrReduction -= TT_PV_LMR_SCALER + (512 * pvNode);
+            lmrReduction -= TT_PV_LMR_SCALER + (512 * pvNode) + (256 * improving);
         }
         
 


### PR DESCRIPTION
------------------------------------------
Elo   | 2.48 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 62512 W: 17759 L: 17313 D: 27440
Penta | [1657, 7488, 12638, 7698, 1775]
https://rektdie.pythonanywhere.com/test/788/
------------------------------------------


bench: 10665769