### PR TITLE
Add Threat History into Quiet History

### DIFF
--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -353,6 +353,10 @@ void get_threats(int side, board* pos) {
 
 }
 
+bool is_square_threatened(board *pos, int square) {
+    return (pos->pieceThreats.stmThreats[!pos->side] & (1ULL << square)) != 0;
+}
+
 // get game phase score
 int get_game_phase_score(const board* position) {
     /*

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -316,12 +316,8 @@ void get_threats(int side, board* pos) {
     kingBB = pos->bitboards[side == white ? K : k];
 
     // Calculate Knight attacks
-    while (knightBB) {
-        int knightSquare = getLS1BIndex(knightBB);
-        pos->pieceThreats.knightThreats |= getKnightAttacks(knightSquare);
-        pos->pieceThreats.stmThreats[pos->side] |= pos->pieceThreats.knightThreats;
-        popBit(knightBB, knightSquare);
-    }
+    pos->pieceThreats.knightThreats |= knight_threats(knightBB);
+    pos->pieceThreats.stmThreats[pos->side] |= pos->pieceThreats.knightThreats;
 
     // Calculate Bishop attacks
     while (bishopBB) {
@@ -340,11 +336,7 @@ void get_threats(int side, board* pos) {
     }
 
     // Calculate Pawn attacks
-    U64 forward_pawns = side == white ? (pawnBB >> 8) : (pawnBB << 8);
-    U64 left_attacks =  forward_pawns << 1 & not_a_file;
-    U64 right_attacks = forward_pawns >> 1 & not_h_file;
-
-    pos->pieceThreats.pawnThreats |= left_attacks | right_attacks;
+    pos->pieceThreats.pawnThreats |= pawn_threats(pawnBB, side);
     pos->pieceThreats.stmThreats[pos->side] |= pos->pieceThreats.pawnThreats;
     
     // Calculate Queen attacks

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -112,5 +112,6 @@ void get_threats(int side, board* pos);
 void init_tables();
 int evaluate(board* position);
 void clearStaticEvaluationHistory(board* position);
+bool is_square_threatened(board *pos, int square);
 
 #endif //POTENTIAL_EVALUATION_H

--- a/src/history.c
+++ b/src/history.c
@@ -3,11 +3,11 @@
 //
 
 #include "history.h"
-
+#include "evaluation.h"
 #include "utils.h"
 
-// quietHistory[side to move][fromSquare][toSquare]
-int16_t quietHistory[2][64][64];
+// quietHistory[side to move][fromSquare][toSquare][threatSource][threatTarget]
+int16_t quietHistory[2][64][64][2][2];
 // continuationHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
 int16_t continuationHistory[12][64][12][64];
 // continuationCorrectionHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
@@ -26,14 +26,14 @@ int scaledBonus(int score, int bonus, int gravity) {
     return bonus - score * myAbs(bonus) / gravity;
 }
 
-void updateQuietMoveHistory(int bestMove, int side, int depth, moves *badQuiets) {
+void updateQuietMoveHistory(int bestMove, int side, int depth, moves *badQuiets, board *pos) {
     int from = getMoveSource(bestMove);
     int to = getMoveTarget(bestMove);
 
     int bonus = getHistoryBonus(depth);
-    int score = quietHistory[side][from][to];
+    int score = quietHistory[side][from][to][is_square_threatened(pos, from)][is_square_threatened(pos, to)];
 
-    quietHistory[side][from][to] += scaledBonus(score, bonus, maxQuietHistory);
+    quietHistory[side][from][to][is_square_threatened(pos, from)][is_square_threatened(pos, to)] += scaledBonus(score, bonus, maxQuietHistory);
 
     for (int index = 0; index < badQuiets->count; index++) {
         if (badQuiets->moves[index] == bestMove) continue;
@@ -41,9 +41,10 @@ void updateQuietMoveHistory(int bestMove, int side, int depth, moves *badQuiets)
         int badQuietFrom = getMoveSource(badQuiets->moves[index]);
         int badQuietTo = getMoveTarget(badQuiets->moves[index]);
 
-        int badQuietScore = quietHistory[side][badQuietFrom][badQuietTo];        
+        int badQuietScore = quietHistory[side][badQuietFrom][badQuietTo][is_square_threatened(pos, badQuietFrom)][is_square_threatened(pos, badQuietTo)];        
 
-        quietHistory[side][badQuietFrom][badQuietTo] += scaledBonus(badQuietScore, -bonus, maxQuietHistory);
+        quietHistory[side][badQuietFrom][badQuietTo][is_square_threatened(pos, badQuietFrom)][is_square_threatened(pos, badQuietTo)] +=
+        scaledBonus(badQuietScore, -bonus, maxQuietHistory);
     }
 }
 

--- a/src/history.h
+++ b/src/history.h
@@ -22,8 +22,8 @@ enum {
     maxCaptureHistory = 16384
 };
 
-// quietHistory[side to move][fromSquare][toSquare]
-extern int16_t quietHistory[2][64][64];
+// quietHistory[side to move][fromSquare][toSquare][threatSource][threatTarget]
+extern int16_t quietHistory[2][64][64][2][2];
 // continuationHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
 extern int16_t continuationHistory[12][64][12][64];
 // continuationCorrectionHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
@@ -35,7 +35,7 @@ extern int16_t captureHistory[12][64][13];
 
 
 int scaledBonus(int score, int bonus, int gravity);
-void updateQuietMoveHistory(int bestMove, int side, int depth, moves *badQuiets);
+void updateQuietMoveHistory(int bestMove, int side, int depth, moves *badQuiets, board *pos);
 void updatePawnHistory(board *pos, int bestMove, int depth, moves *badQuiets);
 void updateSingleCHScore(board *pos, int move, const int offSet, const int bonus);
 void updateAllCH(board *pos, int move, int bonus);

--- a/src/move.c
+++ b/src/move.c
@@ -1202,3 +1202,23 @@ void addMoveToHistoryList(moves* list, int move) {
         list->count += 1;
     }
 }
+
+U64 pawn_threats(U64 pawnBitboard, int side) {    
+    U64 forward_pawns = side == white ? (pawnBitboard >> 8) : (pawnBitboard << 8);
+    U64 left_attacks =  forward_pawns << 1 & not_a_file;
+    U64 right_attacks = forward_pawns >> 1 & not_h_file;
+
+    return left_attacks | right_attacks;
+}
+
+U64 knight_threats (U64 knightBB) {
+    U64 attacks =  (knightBB & not8And7RankHFile)  >> 15 |
+                   (knightBB & not1And2RanksAFile) << 15 |
+                   (knightBB & not8And7RankAFile)  >> 17 |
+                   (knightBB & not1And2RankHFile)  << 17 |
+                   (knightBB & not8RankAndABFile)  >> 10 |
+                   (knightBB & not1RankAndGHFile)  << 10 |
+                   (knightBB & not8RankAndGHFile)  >> 6  |
+                   (knightBB & not1RankAndABFile)  << 6  ;    
+    return attacks;
+}

--- a/src/move.h
+++ b/src/move.h
@@ -75,5 +75,7 @@ void initSlidersAttacks(int bishop);
 void initLeaperAttacks();
 void addMoveToHistoryList(moves* list, int move);
 bool legalityCheck(int moveFlag, int move, board *position);
+U64 pawn_threats(U64 pawnBitboard, int side);
+U64 knight_threats (U64 knightBB);
 
 #endif //POTENTIAL_MOVE_H

--- a/src/search.c
+++ b/src/search.c
@@ -241,7 +241,7 @@ int scoreMove(int move, board* position) {
         if (position->killerMoves[position->ply][0] == move)
             return 900000000;
                    
-        return quietHistory[position->side][getMoveSource(move)][getMoveTarget(move)] +
+        return quietHistory[position->side][getMoveSource(move)][getMoveTarget(move)][is_square_threatened(position, getMoveSource(move))][is_square_threatened(position, getMoveTarget(move))]  +
                 getContinuationHistoryScore(position, 1, move) +
                     getContinuationHistoryScore(position, 2, move) +
                         getContinuationHistoryScore(position, 4, move) +
@@ -1155,7 +1155,8 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
 
         bool notTactical = getMoveCapture(currentMove) == 0 && getMovePromoted(currentMove) == 0;
 
-        int moveHistory = notTactical ? quietHistory[pos->side][getMoveSource(currentMove)][getMoveTarget(currentMove)] +
+        int moveHistory = notTactical ? quietHistory[pos->side][getMoveSource(currentMove)][getMoveTarget(currentMove)]
+                                        [is_square_threatened(pos, getMoveSource(currentMove))][is_square_threatened(pos, getMoveTarget(currentMove))] +
                 getContinuationHistoryScore(pos, 1, currentMove) + getContinuationHistoryScore(pos, 4, currentMove): 0;
 
         int lmrDepth = myMAX(0, depth - getLmrReduction(depth, legal_moves, notTactical) + moveHistory / 8192);
@@ -1422,7 +1423,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
                     if (notTactical) {
                         // store killer moves
                         pos->killerMoves[pos->ply][0] = bestMove;
-                        updateQuietMoveHistory(bestMove, pos->side, depth, badQuiets);
+                        updateQuietMoveHistory(bestMove, pos->side, depth, badQuiets, pos);
                         updateContinuationHistory(pos, bestMove, depth, badQuiets);
                         updatePawnHistory(pos, bestMove, depth, badQuiets);                       
                         

--- a/src/structs.h
+++ b/src/structs.h
@@ -21,6 +21,8 @@ typedef struct  {
     uint64_t bishopThreats;
     uint64_t rookThreats;
     uint64_t queenThreats;
+    uint64_t kingThreats;
+    uint64_t stmThreats[2];    
 } threats;
 
 typedef struct {

--- a/src/uci.c
+++ b/src/uci.c
@@ -6,7 +6,7 @@
 
 #include "perft.h"
 
-#define VERSION "3.0.5"
+#define VERSION "3.1.5"
 #define BENCH_DEPTH 15
 
 double DEF_TIME_MULTIPLIER = 0.054;


### PR DESCRIPTION
<img width="434" height="239" alt="image" src="https://github.com/user-attachments/assets/9791b3b2-61d2-41ba-bfb1-408ea6d17b08" />

I made an implementation to optimize threats.
Although I got a really good boost for pawn and knight, side to move threat and king threats slowed down quite a bit.
This may seem bad for now, but it can be turned into an advantage with other patches in the future.

<img width="430" height="243" alt="image" src="https://github.com/user-attachments/assets/7345955c-9292-4f7b-ad6a-066532a6aebf" />

I tested threat history with a new branch from the optimize-threats branch and it looks fine for VLTC.


