### PR TITLE
Add King Rook Pawn Correction History

### DIFF
--- a/src/board_constants.c
+++ b/src/board_constants.c
@@ -77,6 +77,7 @@ int mvvLva[12][12] = {
 
 int minorPieces[6] = {B, b, N, n, K, k};
 int majorPieces[4] = {R, r, Q, q};
+int krpPieces[6] = {K, k, R, r, P, p};
 int whiteNonPawnPieces[5] = { R, N, B, Q, K };
 int blackNonPawnPieces[5] = {r, n, b, q, k };
 

--- a/src/board_constants.h
+++ b/src/board_constants.h
@@ -53,6 +53,7 @@ extern char *unicodePieces[12];
 extern int charPieces[];
 extern int minorPieces[6];
 extern int majorPieces[4];
+extern int krpPieces[6];
 extern int whiteNonPawnPieces[5];
 extern int blackNonPawnPieces[5];
 extern int mvvLva[12][12];

--- a/src/fen.c
+++ b/src/fen.c
@@ -108,5 +108,6 @@ void parseFEN(char *fen, board* position) {
     position->majorKey = generateMajorKey(position);
     position->whiteNonPawnKey = generate_white_np_hash_key(position);
     position->blackNonPawnKey = generate_black_np_hash_key(position);
+    position->krpKey = generate_krp_key(position);
 }
 

--- a/src/history.c
+++ b/src/history.c
@@ -14,9 +14,10 @@ int16_t continuationHistory[12][64][12][64];
 int16_t contCorrhist[12][64][12][64];
 // pawnHistory [pawnKey][piece][to]
 int16_t pawnHistory[2048][12][64];
-// captureHistory[piece][toSquare][capturedPiece]
+// captureHistory [piece][toSquare][capturedPiece]
 int16_t captureHistory[12][64][13];
-
+// kingRookPawn Correction History [side to move][key]
+int16_t krpCorrhist[2][16384];
 
 int getHistoryBonus(int depth) {
     return myMIN(10 + 200 * depth, 4096);

--- a/src/history.h
+++ b/src/history.h
@@ -32,7 +32,8 @@ extern int16_t contCorrhist[12][64][12][64];
 extern int16_t pawnHistory[2048][12][64];
 // captureHistory[piece][toSquare][capturedPiece]
 extern int16_t captureHistory[12][64][13];
-
+// kingRookPawn Correction History [side to move][key]
+extern int16_t krpCorrhist[2][16384];
 
 int scaledBonus(int score, int bonus, int gravity);
 void updateQuietMoveHistory(int bestMove, int side, int depth, moves *badQuiets, board *pos);

--- a/src/search.c
+++ b/src/search.c
@@ -481,16 +481,32 @@ void update_continuation_corrhist(board *pos, const int depth, const int diff) {
     update_single_cont_corrhist_entry(pos, 4, scaledDiff, newWeight);
 }
 
+void update_king_rook_pawn_corrhist(board *position, const int depth, const int diff) {
+    U64 kingRookPawnKey = position->krpKey;
+
+    int entry = krpCorrhist[position->side][kingRookPawnKey % CORRHIST_SIZE];
+
+    const int scaledDiff = diff * CORRHIST_GRAIN;
+    const int newWeight = 4 * myMIN(depth + 1, 16);
+
+    entry = (entry * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
+    entry = clamp(entry, -CORRHIST_MAX, CORRHIST_MAX);
+
+    krpCorrhist[position->side][kingRookPawnKey % CORRHIST_SIZE] = entry;
+}
+
 int adjustEvalWithCorrectionHistory(board *pos, int rawEval) {   
     rawEval = rawEval * (300 - pos->fifty) / 300;
     
     U64 pawnKey = pos->pawnKey;
     U64 minorKey = pos->minorKey;
     U64 majorKey = pos->majorKey;
+    U64 krpKey = pos->krpKey;
 
     int pawnEntry = PAWN_CORRECTION_HISTORY[pos->side][pawnKey % CORRHIST_SIZE];
     int minorEntry = MINOR_CORRECTION_HISTORY[pos->side][minorKey % CORRHIST_SIZE];
     int majorEntry = MAJOR_CORRECTION_HISTORY[pos->side][majorKey % CORRHIST_SIZE];
+    int krpEntry = krpCorrhist[pos->side][krpKey % CORRHIST_SIZE];
 
     U64 whiteNPKey = pos->whiteNonPawnKey;
     int whiteNPEntry = NON_PAWN_CORRECTION_HISTORY[white][pos->side][whiteNPKey % CORRHIST_SIZE];
@@ -502,7 +518,7 @@ int adjustEvalWithCorrectionHistory(board *pos, int rawEval) {
 
     int mateFound = mateValue - maxPly;
 
-    int adjust = pawnEntry + minorEntry + majorEntry + whiteNPEntry + blackNPEntry + contCorrhistEntry;
+    int adjust = pawnEntry + minorEntry + majorEntry + whiteNPEntry + blackNPEntry + contCorrhistEntry + krpEntry;
 
     return clamp(rawEval + adjust / CORRHIST_GRAIN, -mateFound + 1, mateFound - 1);
 }
@@ -1472,6 +1488,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             updateMajorCorrectionHistory(pos, depth, corrhistBonus);
             update_non_pawn_corrhist(pos, depth, corrhistBonus);
             update_continuation_corrhist(pos, depth, corrhistBonus);
+            update_king_rook_pawn_corrhist(pos, depth, corrhistBonus);
         }
 
         // store hash entry with the score equal to alpha

--- a/src/structs.h
+++ b/src/structs.h
@@ -63,9 +63,10 @@ typedef struct {
     U64 hashKey;
     U64 pawnKey;
     U64 minorKey;
-    U64 majorKey;
+    U64 majorKey;    
     U64 whiteNonPawnKey;
     U64 blackNonPawnKey;
+    U64 krpKey;
 
     int gamePhase;
 } board;
@@ -102,6 +103,7 @@ struct copyposition {
     U64 majorKeyCopy;
     U64 whiteNonPawnKeyCopy;
     U64 blackNonPawnKeyCopy;
+    U64 krpKeyCopy;
 
     int fiftyCopy;
 

--- a/src/table.c
+++ b/src/table.c
@@ -182,6 +182,28 @@ U64 generate_black_np_hash_key(board *position) {
     return final_key;
 }
 
+U64 generate_krp_key(board *position) {
+    uint64_t final_key = 0ULL;
+    uint64_t bitboard;
+
+
+    for (int i = 0; i < 6; i++) {
+
+        int piece = krpPieces[i];
+        bitboard = position->bitboards[piece];
+
+        while (bitboard) {
+
+            int square = getLS1BIndex(bitboard);
+
+            final_key ^= pieceKeys[piece][square];
+            popBit(bitboard, square);
+        }
+    }
+
+    return final_key;
+}
+
 uint64_t get_hash_index(uint64_t hash) {
     return ((uint128_t)hash * (uint128_t)hash_entries) >> 64;
 }

--- a/src/table.h
+++ b/src/table.h
@@ -41,6 +41,7 @@ U64 generateMinorKey(board *position);
 U64 generateMajorKey(board *position);
 U64 generate_white_np_hash_key(board *position);
 U64 generate_black_np_hash_key(board *position);
+U64 generate_krp_key(board *position);
 void clearHashTable(void);
 void init_hash_table(int mb);
 void initRandomKeys(void);

--- a/src/uci.c
+++ b/src/uci.c
@@ -6,8 +6,8 @@
 
 #include "perft.h"
 
-#define VERSION "3.1.5"
-#define BENCH_DEPTH 15
+#define VERSION "3.2.5"
+#define BENCH_DEPTH 14
 
 double DEF_TIME_MULTIPLIER = 0.054;
 double DEF_INC_MULTIPLIER = 0.85;


### PR DESCRIPTION
---------------------------------------------------
Elo   | -4.22 +- 5.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8318 W: 2306 L: 2407 D: 3605
Penta | [251, 1031, 1690, 942, 245]
https://rektdie.pythonanywhere.com/test/1163/
---------------------------------------------------
---------------------------------------------------
Elo   | 2.02 +- 1.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 84968 W: 21056 L: 20561 D: 43351
Penta | [1263, 10200, 19180, 10461, 1380]
https://rektdie.pythonanywhere.com/test/1173/
---------------------------------------------------