### PR TITLE
Add Futility LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1368,7 +1368,8 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             }
 
             // Futility LMR
-            lmrReduction += (static_eval + 164 + 41 * depth <= alpha) * 1024;
+            lmrReduction += (static_eval + 164 + 82 * depth <= alpha && !in_check) * 1024;
+
 
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;

--- a/src/search.c
+++ b/src/search.c
@@ -1368,7 +1368,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             }
 
             // Futility LMR
-            lmrReduction += ((static_eval + LMR_FUTILITY_OFFSET[clamp(depth, 1, 5)]) + 82 * depth <= alpha) * 1024;
+            lmrReduction += (static_eval + 164 + 100 * depth <= alpha) * 1024;
 
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;

--- a/src/search.c
+++ b/src/search.c
@@ -1366,6 +1366,9 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
                 lmrReduction += QUIET_NON_PV_LMR_SCALER;
             }
 
+            // Futility LMR
+            lmrReduction += (static_eval + 164 + 82 * depth <= alpha) * 1024;
+
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;
             lmrReduction -= clamp(moveHistoryReduction * 1024, -QUIET_HISTORY_LMR_MINIMUM_SCALER, QUIET_HISTORY_LMR_MINIMUM_SCALER);

--- a/src/search.c
+++ b/src/search.c
@@ -51,6 +51,7 @@
   int TT_PV_LMR_SCALER = 1024;
   int TT_PV_FAIL_LOW_LMR_SCALER = 1024;
   int TT_CAPTURE_LMR_SCALER = 1024;
+  int LMR_FUTILITY_OFFSET[] = {0, 164, 82, 41, 20, 10};
   
   
   /*╔═══════════════════════╗
@@ -1367,7 +1368,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             }
 
             // Futility LMR
-            lmrReduction += (static_eval + 164 + 82 * depth <= alpha) * 512;
+            lmrReduction += ((static_eval + LMR_FUTILITY_OFFSET[clamp(depth, 1, 5)]) + 82 * depth <= alpha) * 1024;
 
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;

--- a/src/search.c
+++ b/src/search.c
@@ -1368,7 +1368,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             }
 
             // Futility LMR
-            lmrReduction += (static_eval + 164 + 100 * depth <= alpha) * 1024;
+            lmrReduction += (static_eval + 82 + 123 * depth <= alpha) * 1024;
 
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;

--- a/src/search.c
+++ b/src/search.c
@@ -1368,7 +1368,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             }
 
             // Futility LMR
-            lmrReduction += (static_eval + 82 + 123 * depth <= alpha) * 1024;
+            lmrReduction += (static_eval + 164 + 41 * depth <= alpha) * 1024;
 
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;

--- a/src/search.c
+++ b/src/search.c
@@ -1367,7 +1367,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
             }
 
             // Futility LMR
-            lmrReduction += (static_eval + 164 + 82 * depth <= alpha) * 1024;
+            lmrReduction += (static_eval + 164 + 82 * depth <= alpha) * 512;
 
             // if the move have good history decrease reduction other hand the move have bad history then reduce more
             int moveHistoryReduction = moveHistory / QUIET_HISTORY_LMR_DIVISOR;

--- a/src/uci.c
+++ b/src/uci.c
@@ -6,7 +6,7 @@
 
 #include "perft.h"
 
-#define VERSION "3.2.8"
+#define VERSION "3.2.9"
 #define BENCH_DEPTH 13
 
 double DEF_TIME_MULTIPLIER = 0.054;


### PR DESCRIPTION
```
Elo   | 3.28 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30408 W: 8383 L: 8096 D: 13929
Penta | [738, 3620, 6257, 3795, 794]
https://rektdie.pythonanywhere.com/test/1295/
```