### PR TITLE
Don't let negative depth for LMR table

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -386,7 +386,7 @@ void printMove(int move) {
 }
 
 int getLmrReduction(int depth, int moveNumber, bool isQuiet) {
-    return LMR_TABLE[isQuiet][myMIN(63, depth)][myMIN(63, moveNumber)];
+    return LMR_TABLE[isQuiet][myMIN(63, myMAX(depth, 0))][myMIN(63, moveNumber)];
 }
 
 void updatePawnCorrectionHistory(board *position, const int depth, const int diff) {


### PR DESCRIPTION
```
Elo   | 18.71 +- 13.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 1078 W: 320 L: 262 D: 496
Penta | [18, 114, 229, 148, 30]
https://rektdie.pythonanywhere.com/test/1318/
```