### PR TITLE
Tweak NMP fail high formula with constant margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1047,7 +1047,7 @@ int negamax(int alpha, int beta, int depth, board* pos, my_time* time, bool cutN
     // Null Move Pruning
     if (!pos->isSingularMove[pos->ply] && !pvNode &&
         depth >= NMP_DEPTH && !in_check && !rootNode &&
-            ttAdjustedEval >= beta &&
+            ttAdjustedEval >= beta + 30 &&
             pos->ply >= pos->nmpPly &&
             !justPawns(pos)) {
         struct copyposition copyPosition;


### PR DESCRIPTION
```
Elo   | 5.77 +- 3.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 13302 W: 3720 L: 3499 D: 6083
Penta | [306, 1552, 2769, 1663, 361]
https://rektdie.pythonanywhere.com/test/1361/
```