### PR TITLE
handle enpassant moves in gives check function

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -92,8 +92,12 @@ bool move_gives_check(uint16_t move, board* pos) {
     uint8_t piece_type = getMovePromote(move) ? getMovePromotedPiece(pos->side, move) : pos->mailbox[sourceSquare];
     // opponent king square
     uint8_t opponent_king_square = getLS1BIndex(pos->bitboards[pos->side == white ? k : K]);
-
-    // TO:DO: ENPASSANT
+    
+    if (getMoveEnpassant(move)) {        
+        if (pawnAttacks[pos->side][targetSquare] & (1ULL << opponent_king_square)) {            
+            return true;
+        }
+    }
 
     if (getMoveCastling(move)) {
         switch (targetSquare) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.72"
+#define VERSION "3.36.73"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -0.90 +- 1.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 65676 W: 18412 L: 18582 D: 28682
Penta | [1564, 7526, 14818, 7376, 1554]
```
https://rektdie.pythonanywhere.com/test/4279/


bench: 10800905