### PR TITLE
remove king open file bonus

### DIFF
--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -379,10 +379,8 @@ int evaluate(board* position) {
     int b_shield = countBits(kingAttacks[blackKingSquare] & position->occupancies[black]);
     score -= S(b_shield * king_shield_bonus_middlegame, b_shield * king_shield_bonus_endgame);
     
-    if ((position->bitboards[P] & fileMasks[whiteKingSquare]) == 0) score -= S(king_semi_open_file_score, king_semi_open_file_score);
-    if (((position->bitboards[P] | position->bitboards[p]) & fileMasks[whiteKingSquare]) == 0) score -= S(king_open_file_score, king_open_file_score);
-    if ((position->bitboards[p] & fileMasks[blackKingSquare]) == 0) score += S(king_semi_open_file_score, king_semi_open_file_score);
-    if (((position->bitboards[P] | position->bitboards[p]) & fileMasks[blackKingSquare]) == 0) score += S(king_open_file_score, king_open_file_score);            
+    if ((position->bitboards[P] & fileMasks[whiteKingSquare]) == 0) score -= S(king_semi_open_file_score, king_semi_open_file_score);    
+    if ((position->bitboards[p] & fileMasks[blackKingSquare]) == 0) score += S(king_semi_open_file_score, king_semi_open_file_score);    
 
     // Unpack ve Final Interpolation
     int mg = mg_of(score);

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.73"
+#define VERSION "3.36.74"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -0.99 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 69476 W: 19511 L: 19709 D: 30256
Penta | [1873, 8367, 14441, 8199, 1858]
```
https://rektdie.pythonanywhere.com/test/4301/


bench: 11221188