### PR TITLE
remove threats eval term

### DIFF
--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -356,22 +356,6 @@ int evaluate(board* position) {
     
     uint64_t bKingRing = kingAttacks[blackKingSquare];
     uint64_t wKingRing = kingAttacks[whiteKingSquare];
-
-    int wThreats = ((position->pieceThreats.pawnThreats & bKingRing) != 0) * 3 +
-                   ((position->pieceThreats.knightThreats & bKingRing) != 0) * 8 +
-                   ((position->pieceThreats.bishopThreats & bKingRing) != 0) * 8 +
-                   ((position->pieceThreats.rookThreats & bKingRing) != 0) * 12 +
-                   ((position->pieceThreats.queenThreats & bKingRing) != 0) * 25;
-    if (wThreats > 25) wThreats += (wThreats / 8 * 4);
-
-    int bThreats = ((position->pieceThreats.pawnThreats & wKingRing) != 0) * 3 +
-                   ((position->pieceThreats.knightThreats & wKingRing) != 0) * 8 +
-                   ((position->pieceThreats.bishopThreats & wKingRing) != 0) * 8 +
-                   ((position->pieceThreats.rookThreats & wKingRing) != 0) * 12 +
-                   ((position->pieceThreats.queenThreats & wKingRing) != 0) * 25;
-    if (bThreats > 25) bThreats += (bThreats / 8 * 4);
-
-    score += (position->side == white) ? S(wThreats, wThreats) : -S(bThreats, bThreats);
     
     int w_shield = countBits(kingAttacks[whiteKingSquare] & position->occupancies[white]);
     score += S(w_shield * king_shield_bonus_middlegame, w_shield * king_shield_bonus_endgame);

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.74"
+#define VERSION "3.36.75"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -0.10 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 30348 W: 8472 L: 8481 D: 13395
Penta | [835, 3570, 6299, 3709, 761]
```
https://rektdie.pythonanywhere.com/test/4345/


bench: 11332003