### PR TITLE
optimize pawn bb check and fix movegenerator bugs

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -745,6 +745,19 @@ void legal_make_move(uint16_t move, board* position) {
 
     // handle double pawn push
     if (doublePush) {
+        uint8_t stm_king_rank = get_rank[getLS1BIndex(position->bitboards[position->side == white ? K : k])];
+        uint8_t pawn_rank = get_rank[sourceSquare];
+        
+        printf("stm king rank: %d\n", stm_king_rank);
+        printf("pawn rank: %d\n", pawn_rank);
+
+        U64 occ = position->occupancies[both];
+
+        // remove the captured pawn from the occupancy
+        popBit(occ, targetSquare);
+
+        printBitboard(occ);
+
         // set enpassant square
         position->enpassant = targetSquare + enPassantSquares[position->side];
 
@@ -1053,8 +1066,8 @@ void legal_move_generator(moves *moveList, board* pos) {
         U64 rEnemy = bitboard & not_h_file & (enemy << 7);
         U64 lSingleCapt = lEnemy & 0x00FFFFFFFFFF0000 & (evasion_mask << 9) & king_anti_diag_mask[1][stm_king_square];
         U64 rSingleCapt = rEnemy & 0x00FFFFFFFFFF0000 & (evasion_mask << 7) & king_anti_diag_mask[0][stm_king_square];
-        U64 lPromotions = lEnemy & 0x000000000000FF00 & (evasion_mask << 9);
-        U64 rPromotions = rEnemy & 0x000000000000FF00 & (evasion_mask << 7);
+        U64 lPromotions = lEnemy & 0x000000000000FF00 & (evasion_mask << 9) & king_anti_diag_mask[1][stm_king_square];
+        U64 rPromotions = rEnemy & 0x000000000000FF00 & (evasion_mask << 7) & king_anti_diag_mask[0][stm_king_square];
 
         splatPawnSingleMoves(moveList, lSingleCapt, -9, 1);
         splatPawnSingleMoves(moveList, rSingleCapt, -7, 1);
@@ -1078,8 +1091,8 @@ void legal_move_generator(moves *moveList, board* pos) {
         U64 rEnemy = bitboard & not_h_file & (enemy >> 9);
         U64 lSingleCapt = lEnemy & 0x0000FFFFFFFFFF00 & (evasion_mask >> 7) & king_anti_diag_mask[0][stm_king_square];
         U64 rSingleCapt = rEnemy & 0x0000FFFFFFFFFF00 & (evasion_mask >> 9) & king_anti_diag_mask[1][stm_king_square];
-        U64 lPromotions = lEnemy & 0x00FF000000000000 & (evasion_mask >> 7);
-        U64 rPromotions = rEnemy & 0x00FF000000000000 & (evasion_mask >> 9);
+        U64 lPromotions = lEnemy & 0x00FF000000000000 & (evasion_mask >> 7) & king_anti_diag_mask[0][stm_king_square];
+        U64 rPromotions = rEnemy & 0x00FF000000000000 & (evasion_mask >> 9) & king_anti_diag_mask[1][stm_king_square];
 
         splatPawnSingleMoves(moveList, lSingleCapt, +7, 1);
         splatPawnSingleMoves(moveList, rSingleCapt, +9, 1);

--- a/src/move.c
+++ b/src/move.c
@@ -745,7 +745,9 @@ void legal_make_move(uint16_t move, board* position) {
 
     // handle double pawn push
     if (doublePush) {
-        uint8_t stm_king_rank = get_rank[getLS1BIndex(position->bitboards[position->side == white ? K : k])];
+        // TO-DO: check legality for enpassant
+
+        /*uint8_t stm_king_rank = get_rank[getLS1BIndex(position->bitboards[position->side == white ? K : k])];
         uint8_t pawn_rank = get_rank[sourceSquare];
         
         printf("stm king rank: %d\n", stm_king_rank);
@@ -756,7 +758,7 @@ void legal_make_move(uint16_t move, board* position) {
         // remove the captured pawn from the occupancy
         popBit(occ, targetSquare);
 
-        printBitboard(occ);
+        printBitboard(occ);*/
 
         // set enpassant square
         position->enpassant = targetSquare + enPassantSquares[position->side];

--- a/src/perft.c
+++ b/src/perft.c
@@ -2,6 +2,7 @@
 // Created by erena on 13.09.2024.
 //
 
+#include <string.h>
 #include "perft.h"
 
 U64 perftNodes = 0;
@@ -99,6 +100,12 @@ void perft_root_legal_bulk(int depth, board* position) {
         legal_make_move(moveList->moves[moveCount], position);
         perft_child_legal_bulk(depth - 1, position);
 
+        if (depth == 2 &&
+            strcmp(squareToCoordinates[getMoveSource(moveList->moves[moveCount])], "f2") == 0 &&
+            strcmp(squareToCoordinates[getMoveTarget(moveList->moves[moveCount])], "f4") == 0) {
+            printf("Debug: Move f2f4 has %llu nodes at depth %d\n", variant, depth);
+            printBoard(position);
+        }
         printf("%s%s", squareToCoordinates[getMoveSource(moveList->moves[moveCount])],
                squareToCoordinates[getMoveTarget(moveList->moves[moveCount])]);
         if (getMovePromote(moveList->moves[moveCount])) {
@@ -112,7 +119,7 @@ void perft_root_legal_bulk(int depth, board* position) {
     printf("\n");
 }
 
-char* perftSuitFens[126] = {
+char* perftSuitFens[128] = {
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 ;D1 20 ;D2 400 ;D3 8902 ;D4 197281 ;D5 4865609 ;D6 119060324",
     "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1 ;D1 48 ;D2 2039 ;D3 97862 ;D4 4085603 ;D5 193690690",
     "4k3/8/8/8/8/8/8/4K2R w K - 0 1 ;D1 15 ;D2 66 ;D3 1197 ;D4 7059 ;D5 133987 ;D6 764643",
@@ -239,6 +246,8 @@ char* perftSuitFens[126] = {
     "n1n5/1Pk5/8/8/8/8/5Kp1/5N1N b - - 0 1 ;D1 24 ;D2 421 ;D3 7421 ;D4 124608 ;D5 2193768 ;D6 37665329",
     "8/PPPk4/8/8/8/8/4Kppp/8 b - - 0 1 ;D1 18 ;D2 270 ;D3 4699 ;D4 79355 ;D5 1533145 ;D6 28859283",
     "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1 ;D1 24 ;D2 496 ;D3 9483 ;D4 182838 ;D5 3605103 ;D6 71179139",
+    "2rr4/3P4/6p1/3K1pkp/8/3P2PP/R4P2/8 w - - 0 47 ;D1 20 ;D2 329 ;D3 6502 ;D4 123256 ;D5 2534848 ;D6 50037988",
+    "5k2/1p4pp/3n4/p7/3P4/7P/P1KBrpP1/4RR2 b - - 0 26 ;D1 26 ;D2 591 ;D3 15315 ;D4 382679 ;D5 9953105 ;D6 257424294",
     };
 
 // Extracts depths from a suitFen string
@@ -268,7 +277,7 @@ int extractDepths(char* suitFen, int* depths) {
 void perftSuite() {
     int depths[6];
     int correctCount = 0;
-    int totalCount = 126;
+    int totalCount = 128; // Total number of positions in the suite
 
     for (int i = 0; i < totalCount; i++) {
         board position;

--- a/src/perft.h
+++ b/src/perft.h
@@ -12,7 +12,7 @@
 #include "fen.h"
 
 
-extern char* perftSuitFens[126];
+extern char* perftSuitFens[128];
 extern U64 perftNodes;
 extern U64 variant;
 

--- a/src/search.c
+++ b/src/search.c
@@ -485,10 +485,13 @@ int getLmrReduction(int depth, int moveNumber, bool isQuiet) {
 }
 
 uint8_t justPawns(board *pos) {
-    return !((pos->bitboards[N] | pos->bitboards[n] | pos->bitboards[B] |
-              pos->bitboards[b] | pos->bitboards[R] | pos->bitboards[r] |
-              pos->bitboards[Q] | pos->bitboards[q]) &
-             pos->occupancies[pos->side]);
+    switch (pos->side) {
+        case white:
+        return (pos->bitboards[P] | pos->bitboards[K]) == pos->occupancies[white];
+        case black:
+        return (pos->bitboards[p] | pos->bitboards[k]) == pos->occupancies[black];
+    }
+    return 0;
 }
 
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.77"
+#define VERSION "3.36.78"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -0.89 +- 2.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 20584 W: 5684 L: 5737 D: 9163
Penta | [437, 2370, 4711, 2357, 417]
```
https://rektdie.pythonanywhere.com/test/4383/

```
Elo   | 0.29 +- 2.11 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 22886 W: 5138 L: 5119 D: 12629
Penta | [86, 2153, 6944, 2176, 84]
```
https://rektdie.pythonanywhere.com/test/4390/

bench: 10937898