### PR TITLE
add missing masks in noisy generator

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1340,9 +1340,10 @@ void legal_noisy_generator(moves *moveList, board* pos) {
         U64 rEnemy = bitboard & not_h_file & (enemy << 7);
         U64 lSingleCapt = lEnemy & 0x00FFFFFFFFFF0000 & (evasion_mask << 9) & king_anti_diag_mask[1][stm_king_square];
         U64 rSingleCapt = rEnemy & 0x00FFFFFFFFFF0000 & (evasion_mask << 7) & king_anti_diag_mask[0][stm_king_square];
-        U64 lPromotions = lEnemy & 0x000000000000FF00 & (evasion_mask << 9);
-        U64 rPromotions = rEnemy & 0x000000000000FF00 & (evasion_mask << 7);
+        U64 lPromotions = lEnemy & 0x000000000000FF00 & (evasion_mask << 9) & king_anti_diag_mask[1][stm_king_square];
+        U64 rPromotions = rEnemy & 0x000000000000FF00 & (evasion_mask << 7) & king_anti_diag_mask[0][stm_king_square];
 
+        
         splatPawnSingleMoves(moveList, lSingleCapt, -9, 1);
         splatPawnSingleMoves(moveList, rSingleCapt, -7, 1);
         splatPawnPromoMoves(moveList, lPromotions, -9, white, 1);
@@ -1361,8 +1362,8 @@ void legal_noisy_generator(moves *moveList, board* pos) {
         U64 rEnemy = bitboard & not_h_file & (enemy >> 9);
         U64 lSingleCapt = lEnemy & 0x0000FFFFFFFFFF00 & (evasion_mask >> 7) & king_anti_diag_mask[0][stm_king_square];
         U64 rSingleCapt = rEnemy & 0x0000FFFFFFFFFF00 & (evasion_mask >> 9) & king_anti_diag_mask[1][stm_king_square];
-        U64 lPromotions = lEnemy & 0x00FF000000000000 & (evasion_mask >> 7);
-        U64 rPromotions = rEnemy & 0x00FF000000000000 & (evasion_mask >> 9);
+        U64 lPromotions = lEnemy & 0x00FF000000000000 & (evasion_mask >> 7) & king_anti_diag_mask[0][stm_king_square];
+        U64 rPromotions = rEnemy & 0x00FF000000000000 & (evasion_mask >> 9) & king_anti_diag_mask[1][stm_king_square];
 
         splatPawnSingleMoves(moveList, lSingleCapt, +7, 1);
         splatPawnSingleMoves(moveList, rSingleCapt, +9, 1);

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.78"
+#define VERSION "3.36.79"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 2.00 +- 5.51 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 7108 W: 2122 L: 2081 D: 2905
Penta | [191, 846, 1463, 839, 215]
```
https://rektdie.pythonanywhere.com/test/4402/


bench: 10937886