### PR TITLE
don't do razoring if tt flag is lower bound

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1146,7 +1146,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
 
     // razoring
     if (!ss->singular_move &&
-        !pvNode && !in_check && depth <= RAZORING_DEPTH) {
+        !pvNode && !in_check && depth <= RAZORING_DEPTH && tt_flag != hashFlagAlpha) {
         int max_razor_index = 4;
         int razor_depth = myMIN(myMIN(depth, RAZORING_DEPTH), max_razor_index);
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.79"
+#define VERSION "3.36.80"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 0.60 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.70 (-2.94, 2.94) [0.00, 5.00]
Games | N: 25952 W: 7207 L: 7162 D: 11583
Penta | [596, 3171, 5420, 3170, 619]
```
https://rektdie.pythonanywhere.com/test/4414/ 

```
Elo   | 0.87 +- 2.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -1.52 (-2.94, 2.94) [0.00, 5.00]
Games | N: 36264 W: 9126 L: 9035 D: 18103
Penta | [449, 4366, 8437, 4405, 475]
```
https://rektdie.pythonanywhere.com/test/4419/

```
Elo   | 3.80 +- 3.05 (95%)
SPRT  | 120.0+1.20s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 7.50]
Games | N: 15548 W: 3877 L: 3707 D: 7964
Penta | [123, 1820, 3739, 1948, 144]
```
https://rektdie.pythonanywhere.com/test/4431/

Credits to: @peregrineshahin

bench: 10830515