### PR TITLE
fix go nodes no bestmove problem

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1815,7 +1815,7 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
         if (time->is_datagen) {
             check_node_limit(time, t);
         } else {
-            if (t->id == 0 && ((time->timeset && startTime >= time->softLimit && t->pos.pvTable[0][0] != 0) || (time->isNodeLimit && total_nodes() >= time->node_limit))) {
+            if (t->id == 0 && ((time->timeset && startTime >= time->softLimit) || (time->isNodeLimit && total_nodes() >= time->node_limit)) && t->pos.pvTable[0][0] != 0) {
                 time->stopped = 1;
                 store_rlx(thread_pool.stop, true);
             } else if (load_rlx(thread_pool.stop)) {
@@ -1831,7 +1831,7 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
             if (time->is_datagen) {
                 check_node_limit(time, t);
             } else {
-                if (t->id == 0 && ((time->timeset && (startTime >= time->softLimit) && t->pos.pvTable[0][0] != 0) || (time->isNodeLimit && total_nodes() >= time->node_limit))) {
+                if (t->id == 0 && ((time->timeset && startTime >= time->softLimit) || (time->isNodeLimit && total_nodes() >= time->node_limit)) && t->pos.pvTable[0][0] != 0) {
                     time->stopped = 1;
                     store_rlx(thread_pool.stop, true);
                 } else if (load_rlx(thread_pool.stop)) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.80"
+#define VERSION "3.36.81"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -396,7 +396,7 @@ void check_node_limit(my_time* time, ThreadData* t) {
             store_rlx(t->search_i.stopped, true);
         }
     } else {
-        if (total_nodes() >= time->node_limit) {
+        if (total_nodes() >= time->node_limit && t->pos.pvTable[0][0] != 0) {
             time->stopped = 1;
             store_rlx(thread_pool.stop, true);
         }
@@ -405,8 +405,6 @@ void check_node_limit(my_time* time, ThreadData* t) {
 
 
 void uciProtocol(int argc, char *argv[], board *position, my_time *time_ctrl) {
-    //ThreadData *threads = init_threads(thread_count);
-
     setup_main_thread(position);
 
     position->ply = 0;


### PR DESCRIPTION
```
Elo   | 0.48 +- 0.59 (95%)
SPRT  | N=5000 Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7900 W: 3383 L: 3372 D: 1145
Penta | [1, 6, 3933, 1, 9]
```
https://rektdie.pythonanywhere.com/test/4461/

bench: 10830515