### PR TITLE
fix enpassant pin legality

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -758,8 +758,6 @@ void legal_make_move(uint16_t move, board* position) {
 
     // handle double pawn push
     if (doublePush) {
-        // en passant horizontal pin check is now handled in move generation
-
         // set enpassant square
         position->enpassant = targetSquare + enPassantSquares[position->side];
 

--- a/src/move.c
+++ b/src/move.c
@@ -514,12 +514,12 @@ void generate_black_queen_side_castling(board *position, moves *moveList) {
 
 // Filter out en passant captures that would expose the king to a horizontal
 inline static U64 ep_pin_filter(const board *pos, U64 attackers, int king_sq, int captured_sq) {
-    if (get_rank[king_sq] != get_rank[captured_sq]) return attackers;
+    if (get_rank[king_sq] != get_rank[captured_sq]) return attackers;    
+    if (attackers & (attackers - 1)) return attackers;
 
     U64 enemy_rq = pos->side == white
         ? (pos->bitboards[r] | pos->bitboards[q])
         : (pos->bitboards[R] | pos->bitboards[Q]);
-    // remove captured pawn + all attackers from occupancy
     U64 occ = pos->occupancies[both] ^ (1ULL << captured_sq) ^ attackers;
 
     return (getRookAttacks(king_sq, occ) & rankMasks[king_sq] & enemy_rq) ? 0 : attackers;

--- a/src/move.c
+++ b/src/move.c
@@ -512,6 +512,19 @@ void generate_black_queen_side_castling(board *position, moves *moveList) {
     }
 }
 
+// Filter out en passant captures that would expose the king to a horizontal
+inline static U64 ep_pin_filter(const board *pos, U64 attackers, int king_sq, int captured_sq) {
+    if (get_rank[king_sq] != get_rank[captured_sq]) return attackers;
+
+    U64 enemy_rq = pos->side == white
+        ? (pos->bitboards[r] | pos->bitboards[q])
+        : (pos->bitboards[R] | pos->bitboards[Q]);
+    // remove captured pawn + all attackers from occupancy
+    U64 occ = pos->occupancies[both] ^ (1ULL << captured_sq) ^ attackers;
+
+    return (getRookAttacks(king_sq, occ) & rankMasks[king_sq] & enemy_rq) ? 0 : attackers;
+}
+
 #if __AVX512VBMI2__
 
 inline static __m512i SPLAT_TEMPLATE_TARGET_HALF() {
@@ -745,20 +758,7 @@ void legal_make_move(uint16_t move, board* position) {
 
     // handle double pawn push
     if (doublePush) {
-        // TO-DO: check legality for enpassant
-
-        /*uint8_t stm_king_rank = get_rank[getLS1BIndex(position->bitboards[position->side == white ? K : k])];
-        uint8_t pawn_rank = get_rank[sourceSquare];
-        
-        printf("stm king rank: %d\n", stm_king_rank);
-        printf("pawn rank: %d\n", pawn_rank);
-
-        U64 occ = position->occupancies[both];
-
-        // remove the captured pawn from the occupancy
-        popBit(occ, targetSquare);
-
-        printBitboard(occ);*/
+        // en passant horizontal pin check is now handled in move generation
 
         // set enpassant square
         position->enpassant = targetSquare + enPassantSquares[position->side];
@@ -888,13 +888,15 @@ void legal_move_generator(moves *moveList, board* pos) {
 
         if (pos->enpassant != no_sq) {
             U64 attackers = bitboard & pawnAttacks[black][pos->enpassant];
+            int capturedPawnSq = pos->enpassant + 8; // the pawn being captured
             // In check: ep is legal if the ep target square is in evasion_mask,
             // OR if the captured pawn IS the checker (checker_square = ep_target ± 8)
             if (checker_count == 1) {
-                int capturedPawnSq = pos->enpassant + 8; // the pawn being captured
                 if (!((1ULL << pos->enpassant) & evasion_mask) && capturedPawnSq != checker_square)
                     attackers = 0;
             }
+            // Filter out horizontal clearance pins
+            attackers = ep_pin_filter(pos, attackers, stm_king_square, capturedPawnSq);
             splatEnpassant(moveList, attackers, pos->enpassant);
         }
     } else {
@@ -923,13 +925,15 @@ void legal_move_generator(moves *moveList, board* pos) {
 
         if (pos->enpassant != no_sq) {
             U64 attackers = bitboard & pawnAttacks[white][pos->enpassant];
+            int capturedPawnSq = pos->enpassant - 8; // the pawn being captured
             // In check: ep is legal if the ep target square is in evasion_mask,
             // OR if the captured pawn IS the checker (checker_square = ep_target - 8)
             if (checker_count == 1) {
-                int capturedPawnSq = pos->enpassant - 8; // the pawn being captured
                 if (!((1ULL << pos->enpassant) & evasion_mask) && capturedPawnSq != checker_square)
                     attackers = 0;
             }
+            // Filter out horizontal clearance pins
+            attackers = ep_pin_filter(pos, attackers, stm_king_square, capturedPawnSq);
             splatEnpassant(moveList, attackers, pos->enpassant);
         }
     }    
@@ -1181,13 +1185,15 @@ void legal_noisy_generator(moves *moveList, board* pos) {
 
         if (pos->enpassant != no_sq) {
             U64 attackers = bitboard & pawnAttacks[black][pos->enpassant];
+            int capturedPawnSq = pos->enpassant + 8; // the pawn being captured
             // In check: ep is legal if the ep target square is in evasion_mask,
             // OR if the captured pawn IS the checker (checker_square = ep_target ± 8)
             if (checker_count == 1) {
-                int capturedPawnSq = pos->enpassant + 8; // the pawn being captured
                 if (!((1ULL << pos->enpassant) & evasion_mask) && capturedPawnSq != checker_square)
                     attackers = 0;
             }
+            // Filter out horizontal clearance pins
+            attackers = ep_pin_filter(pos, attackers, stm_king_square, capturedPawnSq);
             splatEnpassant(moveList, attackers, pos->enpassant);
         }
     } else {
@@ -1212,13 +1218,15 @@ void legal_noisy_generator(moves *moveList, board* pos) {
 
         if (pos->enpassant != no_sq) {
             U64 attackers = bitboard & pawnAttacks[white][pos->enpassant];
+            int capturedPawnSq = pos->enpassant - 8; // the pawn being captured
             // In check: ep is legal if the ep target square is in evasion_mask,
             // OR if the captured pawn IS the checker (checker_square = ep_target - 8)
             if (checker_count == 1) {
-                int capturedPawnSq = pos->enpassant - 8; // the pawn being captured
                 if (!((1ULL << pos->enpassant) & evasion_mask) && capturedPawnSq != checker_square)
                     attackers = 0;
             }
+            // Filter out horizontal clearance pins
+            attackers = ep_pin_filter(pos, attackers, stm_king_square, capturedPawnSq);
             splatEnpassant(moveList, attackers, pos->enpassant);
         }
     }    

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.81"
+#define VERSION "3.36.82"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -0.41 +- 3.77 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 15098 W: 4441 L: 4459 D: 6198
Penta | [436, 1750, 3197, 1728, 438]
```
https://rektdie.pythonanywhere.com/test/4486/

bench: 10830515