### PR TITLE
add reduction bias in lmr and nonpv search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1576,7 +1576,10 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
         if (gives_check) {
             lmrReduction -= GIVES_CHECK_LMR_SCALAR;
         }
-        
+
+        // Dynamic helper thread reduction bias (from Reckless)
+        // giving each thread a different reduction offset that changes over time
+        lmrReduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 128) - 64;
 
         lmrReduction /= 1024;
 

--- a/src/search.c
+++ b/src/search.c
@@ -1579,7 +1579,10 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
 
         // Dynamic helper thread reduction bias
         // ~5% chance of tipping the reduced depth by ±1 ply
-        lmrReduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 102) - 51;
+        bool multithreaded_search = thread_pool.thread_count > 1;
+        if (multithreaded_search) {
+            lmrReduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 102) - 51;
+        }
 
         lmrReduction /= 1024;
 
@@ -1610,7 +1613,10 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
 
             // Dynamic helper thread depth bias for non-PV zero-window search
             // ~5% chance of ±1 ply depth change
-            nonpv_reduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 1078) - 27;
+            bool multithreaded_search = thread_pool.thread_count > 1;
+            if (multithreaded_search) {                
+                nonpv_reduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 1078) - 27;
+            }
 
             nonpv_reduction /= 1024;
             

--- a/src/search.c
+++ b/src/search.c
@@ -1577,9 +1577,9 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             lmrReduction -= GIVES_CHECK_LMR_SCALAR;
         }
 
-        // Dynamic helper thread reduction bias (from Reckless)
-        // giving each thread a different reduction offset that changes over time
-        lmrReduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 128) - 64;
+        // Dynamic helper thread reduction bias
+        // ~5% chance of tipping the reduced depth by ±1 ply
+        lmrReduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 102) - 51;
 
         lmrReduction /= 1024;
 
@@ -1601,12 +1601,20 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             }
         }
         else if (!pvNode || legal_moves > 1) {
+            int nonpv_reduction = new_depth * 1024;
+
             // if we have chance about to dive into quiescence search then extend
             if (currentMove == tt_move && pos->rootDepth > 8 && tt_depth > 1) {
-                new_depth = myMAX(new_depth, 1);
+                nonpv_reduction = myMAX(nonpv_reduction, 1024);
             }
+
+            // Dynamic helper thread depth bias for non-PV zero-window search
+            // ~5% chance of ±1 ply depth change
+            nonpv_reduction += (int)((load_rlx(t->search_i.nodes_searched) + (uint64_t)t->id * 23) % 1078) - 27;
+
+            nonpv_reduction /= 1024;
             
-            score = -negamax(-alpha - 1, -alpha, new_depth, t, time, ss + 1, !predicted_cut_node);
+            score = -negamax(-alpha - 1, -alpha, nonpv_reduction, t, time, ss + 1, !predicted_cut_node);
         }
 
         if (pvNode && (legal_moves == 1 || score > alpha)) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.37.82"
+#define VERSION "3.37.83"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
This allows helpers to take off their blinders and look at a wider variety of variants.

```
Elo   | -4.22 +- 5.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.06 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 6674 W: 1808 L: 1889 D: 2977
Penta | [171, 852, 1364, 787, 163]
```
https://rektdie.pythonanywhere.com/test/4552/

disabled at 1t, it's not suitable for deterministic search

```
Elo   | 9.13 +- 6.36 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 7.50]
Games | N: 4188 W: 1126 L: 1016 D: 2046
Penta | [56, 466, 962, 532, 78]
```
https://rektdie.pythonanywhere.com/test/4544/

bench: 10830515

Credits: @87flowers