### PR TITLE
fix pseudo legal king threats

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -454,6 +454,10 @@ bool is_pseudo_legal(uint16_t move, board *pos) {
             if (!(kingAttacks[source_square] & (1ULL << target_square))) {
                 return false;
             }
+            // Ensure king doesn't move into an attacked square
+            if (pos->pieceThreats.stmThreats[!pos->side] & (1ULL << target_square)) {
+                return false;
+            }
             break;
     }
     

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.37.83"
+#define VERSION "3.37.84"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 0.91 +- 4.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 9122 W: 2471 L: 2447 D: 4204
Penta | [171, 1063, 2089, 1047, 191]
```
https://rektdie.pythonanywhere.com/test/4553/


bench: 10827373