### PR TITLE
remove anti scaling secondary tt aging

### DIFF
--- a/src/table.c
+++ b/src/table.c
@@ -252,12 +252,7 @@ void writeHashEntry(uint64_t key, int16_t score, uint16_t bestMove, uint8_t dept
         hashEntry->flag = hashFlag;
         hashEntry->depth = depth;        
         hashEntry->ttPv = ttPv;
-    } else if (hashEntry->depth >= 5 && hashFlag != hashFlagExact) {        
-        hashEntry->depth--;
     }
-        
-
-    
 }
 
 // read hash entry data

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.36.80"
+#define VERSION "3.36.81"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 5.27 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=32 Hash=384MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 2.50]
Games | N: 13782 W: 3464 L: 3255 D: 7063
Penta | [3, 1331, 4016, 1536, 5]
```
https://furybench.com/test/3068/

```
Elo   | 3.94 +- 2.91 (95%)
SPRT  | 40.0+0.40s Threads=8 Hash=512MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11920 W: 2962 L: 2827 D: 6131
Penta | [1, 1227, 3369, 1362, 1]
```
https://recklesschess.space/test/8122/


```
Elo   | 0.96 +- 3.22 (95%)
SPRT  | 40.0+0.40s Threads=8 Hash=512MB
LLR   | -1.61 (-2.94, 2.94) [0.00, 7.50]
Games | N: 13068 W: 3154 L: 3118 D: 6796
Penta | [85, 1535, 3271, 1545, 98]
```
https://rektdie.pythonanywhere.com/test/4446/

bench: 11554051

I'm considering this a high-level pass because I didn't have the necessary hardware for testing.