### PR TITLE
refactor makemove logic

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -755,6 +755,9 @@ int quiescence(int alpha, int beta, ThreadData *t, my_time* time, SearchStack *s
     // legal moves counter
     int legal_moves = 0;
     
+    struct copyposition copyPosition;
+    // preserve board state once before move loop
+    copyBoard(position, &copyPosition);
 
     // loop over moves within a movelist
     for (int count = 0; count < moveList->count; count++) {
@@ -771,10 +774,6 @@ int quiescence(int alpha, int beta, ThreadData *t, my_time* time, SearchStack *s
                 continue;
             }
         }
-        
-        struct copyposition copyPosition;
-        // preserve board state
-        copyBoard(position, &copyPosition);
 
         // increment ply
         position->ply++;
@@ -1131,6 +1130,10 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
 
             int move_scores[256];
             init_move_scores(capture_promos, move_scores, tt_move, t, ss);
+            struct copyposition probcutCopy;
+            // preserve board state once before probcut loop
+            copyBoard(pos, &probcutCopy);
+
             for (int count = 0; count < capture_promos->count; count++) {
                 pick_next_move(count, capture_promos, move_scores);
                 uint16_t move = capture_promos->moves[count];
@@ -1146,10 +1149,6 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
                 if (!pvNode && !in_check && noisyFPMargin <= alpha) {
                     continue;
                 }
-
-                struct copyposition copyPosition;
-                // preserve board state
-                copyBoard(pos, &copyPosition);
                 // increment ply
                 pos->ply++;
 
@@ -1188,7 +1187,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
                 pos->repetitionIndex--;
 
                 // take move back
-                takeBack(pos, &copyPosition);
+                takeBack(pos, &probcutCopy);
 
                 if (probcut_value >= probcut_beta) {
                     writeHashEntry(pos->hashKey, probcut_value, move, probcut_depth, hashFlagAlpha, tt_pv, pos, pos->fifty);
@@ -1234,6 +1233,10 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
     //int captureMoves = 0;
 
     const int originalAlpha = alpha;
+
+    struct copyposition copyPosition;
+    // preserve board state once before move loop
+    copyBoard(pos, &copyPosition);
 
     uint16_t currentMove = 0;
     // loop over moves within a movelist
@@ -1414,9 +1417,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             extensions++;
         }
 
-        struct copyposition copyPosition;
-        // preserve board state
-        copyBoard(pos, &copyPosition);
+
 
         // increment ply
         pos->ply++;

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.39.85"
+#define VERSION "3.39.86"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 6.02 +- 4.29 (95%)
SPRT  | 3.0+0.03s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10732 W: 3166 L: 2980 D: 4586
Penta | [251, 1161, 2384, 1291, 279]
```
https://rektdie.pythonanywhere.com/test/4669/


bench: 11541142