### PR TITLE
add NUMA awareness

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -69,9 +69,9 @@ void updatePawnHistory(ThreadData *t, uint16_t bestMove, int bonus, int malus, m
     int from = getMoveSource(bestMove);
     int to = getMoveTarget(bestMove);
 
-    int score = t->search_d.pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[from]][to];
+    int score = t->shared_history->pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[from]][to];
 
-    t->search_d.pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[from]][to] += scaledBonus(score, bonus, maxPawnHistory);
+    t->shared_history->pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[from]][to] += scaledBonus(score, bonus, maxPawnHistory);
 
     for (int index = 0; index < badQuiets->count; index++) {
         if (badQuiets->moves[index] == bestMove) continue;
@@ -79,7 +79,7 @@ void updatePawnHistory(ThreadData *t, uint16_t bestMove, int bonus, int malus, m
         int badQuietFrom = getMoveSource(badQuiets->moves[index]);
         int badQuietTo = getMoveTarget(badQuiets->moves[index]);
 
-        t->search_d.pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[badQuietFrom]][badQuietTo] += scaledBonus(score, -malus, maxPawnHistory);
+        t->shared_history->pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[badQuietFrom]][badQuietTo] += scaledBonus(score, -malus, maxPawnHistory);
     }
 }
 
@@ -161,7 +161,7 @@ void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff)
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
     // Masking for faster indexing (assuming SIZE is power of 2)
-    int16_t *entry = &t->search_d.pawn_corrhist[t->pos.side][t->pos.pawnKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->pawn_corrhist[t->pos.side][t->pos.pawnKey & (CORRHIST_SIZE - 1)];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -169,7 +169,7 @@ void update_minor_correction_hist(ThreadData *t, const int depth, const int diff
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
-    int16_t *entry = &t->search_d.minor_corrhist[t->pos.side][t->pos.minorKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->minor_corrhist[t->pos.side][t->pos.minorKey & (CORRHIST_SIZE - 1)];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -177,7 +177,7 @@ void update_major_correction_hist(ThreadData *t, const int depth, const int diff
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
-    int16_t *entry = &t->search_d.major_corrhist[t->pos.side][t->pos.majorKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->major_corrhist[t->pos.side][t->pos.majorKey & (CORRHIST_SIZE - 1)];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -187,10 +187,10 @@ void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff) {
     const int newWeight = 4 * myMIN(depth + 1, 16);
     const int mask = CORRHIST_SIZE - 1;
     
-    int16_t *white_ptr = &t->search_d.non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
+    int16_t *white_ptr = &t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
     apply_corrhist_update(white_ptr, scaledDiff, newWeight);
     
-    int16_t *black_ptr = &t->search_d.non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask];
+    int16_t *black_ptr = &t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask];
     apply_corrhist_update(black_ptr, scaledDiff, newWeight);
 }
 
@@ -198,7 +198,7 @@ void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int di
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
-    int16_t *entry = &t->search_d.krp_corrhist[t->pos.side][t->pos.krpKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->krp_corrhist[t->pos.side][t->pos.krpKey & (CORRHIST_SIZE - 1)];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -210,7 +210,7 @@ void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const
     const int m2 = ss->move;
     
     if (m1 && m2) {        
-        int16_t *entry_ptr = &t->search_d.contCorrhist[prev->piece][getMoveTarget(m1)]
+        int16_t *entry_ptr = &t->shared_history->contCorrhist[prev->piece][getMoveTarget(m1)]
                                          [ss->piece][getMoveTarget(m2)];
                 
         int val = *entry_ptr;
@@ -231,7 +231,7 @@ static inline int adjust_single_cont_corrhist_entry(ThreadData *t, const int pli
     const int m2 = ss->move;
 
     if (m1 && m2) {
-        return t->search_d.contCorrhist[prev->piece][getMoveTarget(m1)]
+        return t->shared_history->contCorrhist[prev->piece][getMoveTarget(m1)]
                                [ss->piece][getMoveTarget(m2)];
     }
     return 0;
@@ -255,12 +255,12 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {
     const int mask = CORRHIST_SIZE - 1;
 
     // Batch memory access    
-    int adjust = t->search_d.pawn_corrhist[side][t->pos.pawnKey & mask]
-               + t->search_d.minor_corrhist[side][t->pos.minorKey & mask]
-               + t->search_d.major_corrhist[side][t->pos.majorKey & mask]
-               + t->search_d.krp_corrhist[side][t->pos.krpKey & mask]
-               + t->search_d.non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask]
-               + t->search_d.non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask]
+    int adjust = t->shared_history->pawn_corrhist[side][t->pos.pawnKey & mask]
+               + t->shared_history->minor_corrhist[side][t->pos.minorKey & mask]
+               + t->shared_history->major_corrhist[side][t->pos.majorKey & mask]
+               + t->shared_history->krp_corrhist[side][t->pos.krpKey & mask]
+               + t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask]
+               + t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask]
                + adjust_single_cont_corrhist_entry(t, 1, ss)
                + adjust_single_cont_corrhist_entry(t, 2, ss)
                + adjust_single_cont_corrhist_entry(t, 3, ss)               
@@ -281,12 +281,12 @@ int get_correction_value(ThreadData *t, SearchStack *ss) {
     const int side = t->pos.side;
     const int mask = CORRHIST_SIZE - 1;
 
-    const int pawn_correction = t->search_d.pawn_corrhist[side][t->pos.pawnKey & mask];
-    const int minor_correction = t->search_d.minor_corrhist[side][t->pos.minorKey & mask];
-    const int major_correction = t->search_d.major_corrhist[side][t->pos.majorKey & mask];
-    const int krp_correction = t->search_d.krp_corrhist[side][t->pos.krpKey & mask];
-    const int white_non_pawn_correction = t->search_d.non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
-    const int black_non_pawn_correction = t->search_d.non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask];
+    const int pawn_correction = t->shared_history->pawn_corrhist[side][t->pos.pawnKey & mask];
+    const int minor_correction = t->shared_history->minor_corrhist[side][t->pos.minorKey & mask];
+    const int major_correction = t->shared_history->major_corrhist[side][t->pos.majorKey & mask];
+    const int krp_correction = t->shared_history->krp_corrhist[side][t->pos.krpKey & mask];
+    const int white_non_pawn_correction = t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
+    const int black_non_pawn_correction = t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask];
     const int continuation_correction = adjust_single_cont_corrhist_entry(t, 2, ss);
     
     int correction = pawn_correction + minor_correction + major_correction +
@@ -299,20 +299,20 @@ int get_correction_value(ThreadData *t, SearchStack *ss) {
 void clear_histories(void) {
     int how_many_threads = thread_pool.thread_count;
 
-    for (int i = 0;i < how_many_threads;i++) {
+    for (int i = 0; i < how_many_threads; i++) {
         memset(thread_pool.threads[i]->search_d.quietHistory, 0, sizeof(thread_pool.threads[i]->search_d.quietHistory));
         memset(thread_pool.threads[i]->search_d.captureHistory, 0, sizeof(thread_pool.threads[i]->search_d.captureHistory));        
         memset(thread_pool.threads[i]->search_d.continuationHistory, 0, sizeof(thread_pool.threads[i]->search_d.continuationHistory));
-        memset(thread_pool.threads[i]->search_d.pawnHistory, 0, sizeof(thread_pool.threads[i]->search_d.pawnHistory));
-
-        memset(thread_pool.threads[i]->search_d.contCorrhist, 0, sizeof(thread_pool.threads[i]->search_d.contCorrhist));
-        memset(thread_pool.threads[i]->search_d.pawn_corrhist, 0, sizeof(thread_pool.threads[i]->search_d.pawn_corrhist));
-        memset(thread_pool.threads[i]->search_d.minor_corrhist, 0, sizeof(thread_pool.threads[i]->search_d.minor_corrhist));
-        memset(thread_pool.threads[i]->search_d.major_corrhist, 0, sizeof(thread_pool.threads[i]->search_d.major_corrhist));
-        memset(thread_pool.threads[i]->search_d.non_pawn_corrhist, 0, sizeof(thread_pool.threads[i]->search_d.non_pawn_corrhist));    
-        memset(thread_pool.threads[i]->search_d.krp_corrhist, 0, sizeof(thread_pool.threads[i]->search_d.krp_corrhist));
     }                        
     
+    // To preserve NUMA first-touch policy, we free and re-allocate the shared histories
+    // instead of memsetting them from the main thread.
+    for (int i = 0; i < thread_pool.shared_history_count; i++) {
+        free(thread_pool.shared_histories[i]);
+        // calloc allocates zeroed memory lazily, ensuring the first thread to write to a page
+        // will cause that page to be physically allocated on its own NUMA node!
+        thread_pool.shared_histories[i] = (SharedHistory *)calloc(1, sizeof(SharedHistory));
+    }
 }
 
 void quiet_history_aging(void) {

--- a/src/history.c
+++ b/src/history.c
@@ -303,15 +303,16 @@ void clear_histories(void) {
         memset(thread_pool.threads[i]->search_d.quietHistory, 0, sizeof(thread_pool.threads[i]->search_d.quietHistory));
         memset(thread_pool.threads[i]->search_d.captureHistory, 0, sizeof(thread_pool.threads[i]->search_d.captureHistory));        
         memset(thread_pool.threads[i]->search_d.continuationHistory, 0, sizeof(thread_pool.threads[i]->search_d.continuationHistory));
-    }                        
+    }
     
-    // To preserve NUMA first-touch policy, we free and re-allocate the shared histories
-    // instead of memsetting them from the main thread.
     for (int i = 0; i < thread_pool.shared_history_count; i++) {
         free(thread_pool.shared_histories[i]);
-        // calloc allocates zeroed memory lazily, ensuring the first thread to write to a page
-        // will cause that page to be physically allocated on its own NUMA node!
         thread_pool.shared_histories[i] = (SharedHistory *)calloc(1, sizeof(SharedHistory));
+    }
+    
+    int threads_per_l3 = 8;
+    for (int i = 0; i < how_many_threads; i++) {
+        thread_pool.threads[i]->shared_history = thread_pool.shared_histories[i / threads_per_l3];
     }
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -391,7 +391,7 @@ int scoreMove(uint16_t move, ThreadData *t, SearchStack *ss) {
         // 4 ply continuation history
         quiet_score += getContinuationHistoryScore(t, 4, move, ss);
         // pawn history
-        quiet_score += t->search_d.pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[getMoveSource(move)]][getMoveTarget(move)];
+        quiet_score += t->shared_history->pawnHistory[t->pos.pawnKey % 2048][t->pos.mailbox[getMoveSource(move)]][getMoveTarget(move)];
         // NMP refutation move
         //quiet_score += getMoveSource(move) == getMoveTarget(position->nmp_refutation_move[position->ply]) ? 500000 : 0;
 
@@ -1252,7 +1252,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
         bool notTactical = !tactical;
         bool gives_check = move_gives_check(currentMove, pos);
 
-        int pawnHistoryValue = notTactical ? t->search_d.pawnHistory[pos->pawnKey % 2048][pos->mailbox[getMoveSource(currentMove)]][getMoveTarget(currentMove)] : 0;
+        int pawnHistoryValue = notTactical ? t->shared_history->pawnHistory[pos->pawnKey % 2048][pos->mailbox[getMoveSource(currentMove)]][getMoveTarget(currentMove)] : 0;
 
         int moveHistory = notTactical ? t->search_d.quietHistory[pos->side][getMoveSource(currentMove)][getMoveTarget(currentMove)]
                                         [is_square_threatened(pos, getMoveSource(currentMove))][is_square_threatened(pos, getMoveTarget(currentMove))] +

--- a/src/search.c
+++ b/src/search.c
@@ -1261,7 +1261,6 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
 
         int lmrDepth = myMAX(0, depth - getLmrReduction(depth, legal_moves, notTactical) + (moveHistory / 8192 * notTactical));
 
-
         bool isNotMated = bestScore > -mateFound;
 
         if (!rootNode && isNotMated && !gives_check) {

--- a/src/structs.h
+++ b/src/structs.h
@@ -183,17 +183,6 @@ typedef struct {
     // pawnHistory [pawnKey][piece][to]
     int16_t pawnHistory[2048][12][64];
 
-    // quietHistory[side to move][fromSquare][toSquare][threatSource][threatTarget]
-    int16_t quietHistory[2][64][64][2][2];
-
-    // continuationHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
-    int16_t continuationHistory[12][64][12][64];    
-
-    // captureHistory [piece][toSquare][capturedPiece]
-    int16_t captureHistory[12][64][13];
-
-     /* Correction Histories */
-    
     // continuationCorrectionHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
     int16_t contCorrhist[12][64][12][64];
 
@@ -211,6 +200,17 @@ typedef struct {
 
     // king rook pawn correction history [side to move][key]
     int16_t krp_corrhist[2][16384];
+} SharedHistory;
+
+typedef struct {
+    // quietHistory[side to move][fromSquare][toSquare][threatSource][threatTarget]
+    int16_t quietHistory[2][64][64][2][2];
+
+    // continuationHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
+    int16_t continuationHistory[12][64][12][64];    
+
+    // captureHistory [piece][toSquare][capturedPiece]
+    int16_t captureHistory[12][64][13];
 } SearchData;
 
 typedef struct {
@@ -225,6 +225,7 @@ typedef struct {
     pthread_t native_handle;
     SearchInfo search_i;
     SearchData search_d;
+    SharedHistory *shared_history;
     board pos;
     SearchStack ss_base[maxPly + 20]; // 20 = STACK_SAFETY_MARGIN
     SearchStack *ss;                   // points to ss_base + STACK_OFFSET (10)
@@ -235,6 +236,9 @@ typedef struct {
 typedef struct {
     ThreadData *threads[MAX_THREADS];
     int thread_count;
+
+    SharedHistory **shared_histories;
+    int shared_history_count;
 
     _Atomic bool stop;    
     board root_pos;    

--- a/src/table.c
+++ b/src/table.c
@@ -223,12 +223,12 @@ void prefetch_corrhist(board *pos, ThreadData *t) {
     const int mask = CORRHIST_SIZE - 1;
     const int side = pos->side;
 
-    __builtin_prefetch(&t->search_d.pawn_corrhist[side][pos->pawnKey & mask]);
-    __builtin_prefetch(&t->search_d.minor_corrhist[side][pos->minorKey & mask]);
-    __builtin_prefetch(&t->search_d.major_corrhist[side][pos->majorKey & mask]);
-    __builtin_prefetch(&t->search_d.non_pawn_corrhist[white][side][pos->whiteNonPawnKey & mask]);
-    __builtin_prefetch(&t->search_d.non_pawn_corrhist[black][side][pos->blackNonPawnKey & mask]);
-    __builtin_prefetch(&t->search_d.krp_corrhist[side][pos->krpKey & mask]);
+    __builtin_prefetch(&t->shared_history->pawn_corrhist[side][pos->pawnKey & mask]);
+    __builtin_prefetch(&t->shared_history->minor_corrhist[side][pos->minorKey & mask]);
+    __builtin_prefetch(&t->shared_history->major_corrhist[side][pos->majorKey & mask]);
+    __builtin_prefetch(&t->shared_history->non_pawn_corrhist[white][side][pos->whiteNonPawnKey & mask]);
+    __builtin_prefetch(&t->shared_history->non_pawn_corrhist[black][side][pos->blackNonPawnKey & mask]);
+    __builtin_prefetch(&t->shared_history->krp_corrhist[side][pos->krpKey & mask]);
 }
 
 void writeHashEntry(uint64_t key, int16_t score, uint16_t bestMove, uint8_t depth, uint8_t hashFlag, bool ttPv, board* position, uint8_t fmr_key) {

--- a/src/threads.c
+++ b/src/threads.c
@@ -1,5 +1,16 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "threads.h"
 #include "search.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__linux__) || defined(__APPLE__)
+#include <sched.h>
+#include <pthread.h>
+#endif
 
 ThreadPool thread_pool;
 
@@ -19,6 +30,18 @@ static void free_threads(void) {
         }
     }
     thread_pool.thread_count = 0;
+
+    for (int i = 0; i < thread_pool.shared_history_count; i++) {
+        if (thread_pool.shared_histories[i] != NULL) {
+            free(thread_pool.shared_histories[i]);
+            thread_pool.shared_histories[i] = NULL;
+        }
+    }
+    if (thread_pool.shared_histories != NULL) {
+        free(thread_pool.shared_histories);
+        thread_pool.shared_histories = NULL;
+    }
+    thread_pool.shared_history_count = 0;
 }
 
 void init_threads(int requested_count) {
@@ -31,6 +54,18 @@ void init_threads(int requested_count) {
     thread_pool.thread_count = requested_count;
     store_rlx(thread_pool.stop, false);
 
+    // Default to 8 threads per L3 Cache domain
+    int threads_per_l3 = 8;
+    thread_pool.shared_history_count = (requested_count + threads_per_l3 - 1) / threads_per_l3;
+    thread_pool.shared_histories = (SharedHistory **)malloc(thread_pool.shared_history_count * sizeof(SharedHistory *));
+
+    for (int i = 0; i < thread_pool.shared_history_count; i++) {
+        thread_pool.shared_histories[i] = (SharedHistory *)calloc(1, sizeof(SharedHistory));
+        // Note: calloc allocates zeroed memory lazily. The physical RAM pages will only be
+        // allocated when the threads first write to them during search, perfectly assigning
+        // the memory to their local NUMA node!
+    }
+
     for (int i = 0; i < requested_count; i++) {
         thread_pool.threads[i] = (ThreadData *)malloc(sizeof(ThreadData));
         
@@ -41,6 +76,7 @@ void init_threads(int requested_count) {
 
         memset(thread_pool.threads[i], 0, sizeof(ThreadData));
         thread_pool.threads[i]->id = i;
+        thread_pool.threads[i]->shared_history = thread_pool.shared_histories[i / threads_per_l3];
         thread_pool.threads[i]->ss = thread_pool.threads[i]->ss_base + STACK_OFFSET;
         clearStaticEvaluationHistory(thread_pool.threads[i]->ss);
     }
@@ -57,6 +93,23 @@ uint64_t total_nodes(void) {
 // Thread entry function for helper threads
 static void *thread_entry(void *arg) {
     ThreadData *t = (ThreadData *)arg;
+
+#if defined(_WIN32)
+    // Pin thread to specific logical processor for NUMA-awareness (Windows)
+    HANDLE native_thread = GetCurrentThread();
+    GROUP_AFFINITY affinity;
+    memset(&affinity, 0, sizeof(GROUP_AFFINITY));
+    affinity.Group = t->id / 64;
+    affinity.Mask = 1ULL << (t->id % 64);
+    SetThreadGroupAffinity(native_thread, &affinity, NULL);
+#elif defined(__linux__)
+    // Pin thread to specific logical processor for NUMA-awareness (Linux)
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(t->id, &cpuset);
+    pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+#endif
+
     searchPosition(t->search_depth, false, t, t->time);
     return NULL;
 }


### PR DESCRIPTION
```
Elo   | 75.78 +- 21.06 (95%)
SPRT  | 20.0+0.20s Threads=8 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 326 W: 117 L: 47 D: 162
Penta | [0, 16, 70, 68, 9]
```
https://rektdie.pythonanywhere.com/test/4706/

```
Elo   | 36.49 +- 14.89 (95%)
SPRT  | 20.0+0.20s Threads=8 Hash=256MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 10.00]
Games | N: 602 W: 181 L: 118 D: 303
Penta | [3, 43, 150, 98, 7]
```
https://rektdie.pythonanywhere.com/test/4709/

```
Elo   | 13.48 +- 8.60 (95%)
SPRT  | 4.0+0.04s Threads=96 Hash=2048MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1754 W: 462 L: 394 D: 898
Penta | [9, 172, 451, 232, 13]
```
https://xsolod3v.pythonanywhere.com/test/566/

thanks for the 96 threaded test to @yunusemreyldz07 

second sane check will added after Styx's benchmark test