### PR TITLE
correction value based ldse adjustment

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1412,9 +1412,13 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
                 extensions -= 2;
             }
         } 
-        // Low Depth Singular Extensions
-        else if (depth <= 7 && !in_check && ttAdjustedEval <= alpha - 25 && predicted_cut_node) {
-            extensions++;
+        // Low Depth Singular Extensions        
+        else if (depth <= 7 && !in_check && predicted_cut_node) {
+            int ldse_margin = alpha - 25;
+            ldse_margin += 768 * abs(correction_value) / 98304;
+            if (ttAdjustedEval <= ldse_margin) {
+                extensions++;
+            }            
         }
 
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.39.86"
+#define VERSION "3.39.87"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 9.13 +- 5.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5442 W: 1445 L: 1302 D: 2695
Penta | [61, 601, 1273, 706, 80]
```
https://rektdie.pythonanywhere.com/test/4712/

bench: 16739959