### PR TITLE
speedup for zobrist keys

### DIFF
--- a/src/board_constants.c
+++ b/src/board_constants.c
@@ -6,7 +6,7 @@
 
 
 // random piece keys [piece][square]
-U64 pieceKeys[12][64];
+ZobristInfo pieceKeys[12][64];
 // random enpassant keys [square]
 U64 enpassantKeys[64];
 // random castling keys

--- a/src/board_constants.h
+++ b/src/board_constants.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "structs.h"
 
 
 #ifndef U64
@@ -64,6 +65,10 @@ inline int pieceColor(int piece) {
     return black;
 }
 
+bool isMinor(int piece);
+bool isMajor(int piece);
+bool isKRP(int piece);
+
 extern char *squareToCoordinates[];
 extern char asciiPieces[];
 extern char promotedPieces[];
@@ -108,7 +113,7 @@ extern const U64 LIGHT_SQUARES;
 /*   Zobrist Hashing   */
 
 // random piece keys [piece][square]
-extern U64 pieceKeys[12][64];
+extern ZobristInfo pieceKeys[12][64];
 // random enpassant keys [square]
 extern U64 enpassantKeys[64];
 // random castling keys

--- a/src/move.c
+++ b/src/move.c
@@ -236,25 +236,8 @@ bool isKRP(int piece) {
 }
 
 inline static void toggleHashesForPiece(board* position, int piece, int square) {
-    position->hashKey ^= pieceKeys[piece][square];
-    if (piece == P || piece == p) {
-        position->pawnKey ^= pieceKeys[piece][square];
-        position->krpKey ^= pieceKeys[piece][square];
-    } else {
-        if (pieceColor(piece) == white) {
-            position->whiteNonPawnKey ^= pieceKeys[piece][square];
-        } else {
-            position->blackNonPawnKey ^= pieceKeys[piece][square];
-        }
-    }
-    if (isMinor(piece)) {
-        position->minorKey ^= pieceKeys[piece][square];
-    }
-    if (isMajor(piece)) {
-        position->majorKey ^= pieceKeys[piece][square];
-    }
-    if (isKRP(piece)) {
-        position->krpKey ^= pieceKeys[piece][square];
+    for (int i = 0; i < 8; i++) {
+        position->zinfo.raw[i] ^= pieceKeys[piece][square].raw[i];
     }
 }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -30,16 +30,36 @@ typedef struct  {
     uint64_t stmThreats[2];    
 } threats;
 
+typedef union {
+    struct {
+        U64 hashKey;
+        U64 pawnKey;
+        U64 minorKey;
+        U64 majorKey;
+        U64 whiteNonPawnKey;
+        U64 blackNonPawnKey;
+        U64 krpKey;
+        U64 padding_key;
+    };
+    U64 raw[8];
+} ZobristInfo;
+
 typedef struct {
     U64 bitboards[12];
     U64 occupancies[3];
-    U64 hashKey;
-    U64 pawnKey;
-    U64 minorKey;
-    U64 majorKey;
-    U64 whiteNonPawnKey;
-    U64 blackNonPawnKey;
-    U64 krpKey;
+    union {
+        ZobristInfo zinfo;
+        struct {
+            U64 hashKey;
+            U64 pawnKey;
+            U64 minorKey;
+            U64 majorKey;
+            U64 whiteNonPawnKey;
+            U64 blackNonPawnKey;
+            U64 krpKey;
+            U64 padding_key;
+        };
+    };
     uint8_t mailbox[64];
     int side;
     int castle;
@@ -76,13 +96,19 @@ typedef struct {
 struct copyposition {
     U64 bitboards[12];
     U64 occupancies[3];
-    U64 hashKey;
-    U64 pawnKey;
-    U64 minorKey;
-    U64 majorKey;
-    U64 whiteNonPawnKey;
-    U64 blackNonPawnKey;
-    U64 krpKey;
+    union {
+        ZobristInfo zinfo;
+        struct {
+            U64 hashKey;
+            U64 pawnKey;
+            U64 minorKey;
+            U64 majorKey;
+            U64 whiteNonPawnKey;
+            U64 blackNonPawnKey;
+            U64 krpKey;
+            U64 padding_key;
+        };
+    };
     uint8_t mailbox[64];
     int side;
     int castle;

--- a/src/table.c
+++ b/src/table.c
@@ -46,7 +46,7 @@ U64 generateHashKey(board* position) {
             int square = getLS1BIndex(bitboard);
 
             // hash piece
-            finalKey ^= pieceKeys[piece][square];
+            finalKey ^= pieceKeys[piece][square].hashKey;
 
             // pop LS1B
             popBit(bitboard, square);
@@ -77,7 +77,7 @@ U64 generatePawnKey(board* position) {
     while (bitboard) {
         int square = getLS1BIndex(bitboard);
 
-        final_key ^= pieceKeys[P][square];
+        final_key ^= pieceKeys[P][square].hashKey;
         popBit(bitboard, square);
     }
 
@@ -86,7 +86,7 @@ U64 generatePawnKey(board* position) {
     while (bitboard) {
         int square = getLS1BIndex(bitboard);
 
-        final_key ^= pieceKeys[p][square];
+        final_key ^= pieceKeys[p][square].hashKey;
         popBit(bitboard, square);
     }
     return final_key;
@@ -107,7 +107,7 @@ U64 generateMinorKey(board *position) {
 
             int square = getLS1BIndex(bitboard);
 
-            final_key ^= pieceKeys[piece][square];
+            final_key ^= pieceKeys[piece][square].hashKey;
             popBit(bitboard, square);
         }
     }
@@ -129,7 +129,7 @@ U64 generateMajorKey(board *position) {
 
             int square = getLS1BIndex(bitboard);
 
-            final_key ^= pieceKeys[piece][square];
+            final_key ^= pieceKeys[piece][square].hashKey;
             popBit(bitboard, square);
         }
     }
@@ -151,7 +151,7 @@ U64 generate_white_np_hash_key(board *position) {
 
             int square = getLS1BIndex(bitboard);
 
-            final_key ^= pieceKeys[piece][square];
+            final_key ^= pieceKeys[piece][square].hashKey;
             popBit(bitboard, square);
         }
     }
@@ -174,7 +174,7 @@ U64 generate_black_np_hash_key(board *position) {
 
             int square = getLS1BIndex(bitboard);
 
-            final_key ^= pieceKeys[piece][square];
+            final_key ^= pieceKeys[piece][square].hashKey;
             popBit(bitboard, square);
         }
     }
@@ -197,7 +197,7 @@ U64 generate_krp_key(board *position) {
 
             int square = getLS1BIndex(bitboard);
 
-            final_key ^= pieceKeys[piece][square];
+            final_key ^= pieceKeys[piece][square].hashKey;
             popBit(bitboard, square);
         }
     }
@@ -390,7 +390,15 @@ void initRandomKeys(void) {
     for (int piece = P; piece <= k; piece++) {
         // loop over board squares
         for (int square = 0; square < 64; square++) {
-            pieceKeys[piece][square] = get_random_uint64_number();
+            U64 key = get_random_uint64_number();
+            pieceKeys[piece][square].hashKey = key;
+            pieceKeys[piece][square].pawnKey = (piece == P || piece == p) ? key : 0;
+            pieceKeys[piece][square].minorKey = (isMinor(piece)) ? key : 0;
+            pieceKeys[piece][square].majorKey = (isMajor(piece)) ? key : 0;
+            pieceKeys[piece][square].whiteNonPawnKey = (piece != P && piece != p && pieceColor(piece) == white) ? key : 0;
+            pieceKeys[piece][square].blackNonPawnKey = (piece != P && piece != p && pieceColor(piece) == black) ? key : 0;
+            pieceKeys[piece][square].krpKey = (isKRP(piece) && piece != P && piece != p) ? key : 0;
+            pieceKeys[piece][square].padding_key = 0;
         }
     }
     // loop over board squares

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.39.88"
+#define VERSION "3.40.88"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 4.95 +- 4.00 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 7.50]
Games | N: 12700 W: 3764 L: 3583 D: 5353
Penta | [312, 1412, 2747, 1541, 338]
```
https://rektdie.pythonanywhere.com/test/4780/

bench: 16739959