### PR TITLE
remove pv move ordering

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -20,8 +20,7 @@ uint16_t get_next_move(MovePicker *mp, int *move_scores, board *pos, ThreadData 
         // fallthrough
         case STAGE_GEN_NOISY:
             mp->CURRENT_STAGE = STAGE_GOOD_NOISY;
-            legal_noisy_generator(&mp->good_noisy, pos);
-            if (pos->followPv) enable_pv_scoring(&mp->good_noisy, pos);
+            legal_noisy_generator(&mp->good_noisy, pos);            
             init_move_scores(&mp->good_noisy, move_scores, mp->tt_move, t, ss);
             mp->good_noisy_index = 0;
         // fallthrough
@@ -47,8 +46,7 @@ uint16_t get_next_move(MovePicker *mp, int *move_scores, board *pos, ThreadData 
         // fallthrough
         case STAGE_GEN_QUIET:
             mp->CURRENT_STAGE = STAGE_QUIET;
-            legal_quiet_generator(&mp->quiet, pos);
-            if (pos->followPv) enable_pv_scoring(&mp->quiet, pos);
+            legal_quiet_generator(&mp->quiet, pos);            
             init_move_scores(&mp->quiet, move_scores, mp->tt_move, t, ss);
             mp->quiet_index = 0;
         // fallthrough

--- a/src/search.c
+++ b/src/search.c
@@ -314,16 +314,7 @@ void init_quiescence_scores(moves *moveList, int *move_scores, board* position) 
 */
 
 // score moves
-int scoreMove(uint16_t move, ThreadData *t, SearchStack *ss) {
-    // make sure we are dealing with PV move
-    if (t->pos.scorePv && t->pos.pvTable[0][t->pos.ply] == move) {
-        // disable score PV flag
-        t->pos.scorePv = 0;
-
-        // give PV move the highest score to search it first
-        return PV_SCORE;
-    }
-
+int scoreMove(uint16_t move, ThreadData *t, SearchStack *ss) {    
     // score promotion move
     if (getMovePromote(move)) {
         switch (getMovePromotedPiece(t->pos.side, move)) {
@@ -406,25 +397,6 @@ int scoreMove(uint16_t move, ThreadData *t, SearchStack *ss) {
         return quiet_score;
     }
     return 0;
-}
-
-
-// enable PV move scoring
-void enable_pv_scoring(moves *moveList, board* position) {
-    // disable following PV
-    position->followPv = 0;
-
-    // loop over the moves within a move list
-    for (int count = 0; count < moveList->count; count++) {
-        // make sure we hit PV move
-        if (position->pvTable[0][position->ply] == moveList->moves[count]) {
-            // enable move scoring
-            position->scorePv = 1;
-
-            // enable following PV
-            position->followPv = 1;
-        }
-    }
 }
 
 int getLmrReduction(int depth, int moveNumber, bool isQuiet) {
@@ -1760,11 +1732,7 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
 
     // reset thread selection fields
     t->search_i.depthCompleted = 0;
-    t->search_i.score = 0;
-
-    // reset follow PV flags
-    t->pos.followPv = 0;
-    t->pos.scorePv = 0;
+    t->search_i.score = 0;    
     
     if (t->id == 0) {
         memset(nodes_spent_table, 0, sizeof(nodes_spent_table));
@@ -1843,8 +1811,7 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
                 alpha = myMAX(-infinity, score - window);
                 beta = myMIN(infinity, score + window);
             }
-
-            t->pos.followPv = 1;
+            
             // find best move within a given position
             int current_score = negamax(alpha, beta, myMAX(aspirationWindowDepth, 1), t, time, ss, false);
             

--- a/src/search.h
+++ b/src/search.h
@@ -30,7 +30,6 @@ int isRepetition(board* position);
 uint8_t isMaterialDraw(board *pos);
 void initializeLMRTable(void);
 int scoreMove(uint16_t move, ThreadData *t, SearchStack *ss);
-void enable_pv_scoring(moves *moveList, board* position);
 void printMove(uint16_t move);
 int getLmrReduction(int depth, int moveNumber, bool isQuiet);
 uint8_t justPawns(board *pos);

--- a/src/structs.h
+++ b/src/structs.h
@@ -85,10 +85,7 @@ typedef struct {
     int pvLength[maxPly];
     int pvTable[maxPly][maxPly];
 
-    bool benchmark;
-
-    int followPv;
-    int scorePv;
+    bool benchmark;    
 
     int gamePhase;
 } board;

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.42.89"
+#define VERSION "3.42.90"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 0.65 +- 3.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 20282 W: 5557 L: 5519 D: 9206
Penta | [394, 2395, 4548, 2387, 417]
```
https://rektdie.pythonanywhere.com/test/4830/


bench: 17142319