### PR TITLE
scale the size of corrhists based on thread count

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -21,7 +21,8 @@
 int CORRHIST_WEIGHT_SCALE = 256;
 int CORRHIST_GRAIN = 256;
 int CORRHIST_LIMIT = 1024;
-int CORRHIST_SIZE = 16384;
+int BASE_CORRHIST_SIZE = 16384;
+int BASE_CONT_CORRHIST_SIZE = 262144;
 int CORRHIST_MAX = 16384;
 
 /* Update History */
@@ -162,7 +163,7 @@ void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff)
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
     // Masking for faster indexing (assuming SIZE is power of 2)
-    int16_t *entry = &t->shared_history->pawn_corrhist[t->pos.side][t->pos.pawnKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->pawn_corrhist[t->pos.side][t->pos.pawnKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -170,7 +171,7 @@ void update_minor_correction_hist(ThreadData *t, const int depth, const int diff
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
-    int16_t *entry = &t->shared_history->minor_corrhist[t->pos.side][t->pos.minorKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->minor_corrhist[t->pos.side][t->pos.minorKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -178,7 +179,7 @@ void update_major_correction_hist(ThreadData *t, const int depth, const int diff
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
-    int16_t *entry = &t->shared_history->major_corrhist[t->pos.side][t->pos.majorKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->major_corrhist[t->pos.side][t->pos.majorKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -186,7 +187,7 @@ void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff) {
     const int side = t->pos.side;
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
-    const int mask = CORRHIST_SIZE - 1;
+    const int mask = t->shared_history->corrhist_mask;
     
     int16_t *white_ptr = &t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
     apply_corrhist_update(white_ptr, scaledDiff, newWeight);
@@ -199,7 +200,7 @@ void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int di
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
     
-    int16_t *entry = &t->shared_history->krp_corrhist[t->pos.side][t->pos.krpKey & (CORRHIST_SIZE - 1)];
+    int16_t *entry = &t->shared_history->krp_corrhist[t->pos.side][t->pos.krpKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
@@ -210,9 +211,9 @@ void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const
     const int m1 = prev->move;
     const int m2 = ss->move;
     
-    if (m1 && m2) {        
-        int16_t *entry_ptr = &t->shared_history->contCorrhist[prev->piece][getMoveTarget(m1)]
-                                         [ss->piece][getMoveTarget(m2)];
+    if (m1 && m2) {
+        uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
+        int16_t *entry_ptr = &t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
                 
         int val = *entry_ptr;
         val = (val * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
@@ -232,8 +233,8 @@ static inline int adjust_single_cont_corrhist_entry(ThreadData *t, const int pli
     const int m2 = ss->move;
 
     if (m1 && m2) {
-        return t->shared_history->contCorrhist[prev->piece][getMoveTarget(m1)]
-                               [ss->piece][getMoveTarget(m2)];
+        uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
+        return t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
     }
     return 0;
 }
@@ -253,7 +254,7 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {
     rawEval = (rawEval * (300 - t->pos.fifty)) / 300;
     
     const int side = t->pos.side;
-    const int mask = CORRHIST_SIZE - 1;
+    const int mask = t->shared_history->corrhist_mask;
 
     // Batch memory access    
     int adjust = t->shared_history->pawn_corrhist[side][t->pos.pawnKey & mask]
@@ -280,7 +281,7 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {
 
 int get_correction_value(ThreadData *t, SearchStack *ss) {
     const int side = t->pos.side;
-    const int mask = CORRHIST_SIZE - 1;
+    const int mask = t->shared_history->corrhist_mask;
 
     const int pawn_correction = t->shared_history->pawn_corrhist[side][t->pos.pawnKey & mask];
     const int minor_correction = t->shared_history->minor_corrhist[side][t->pos.minorKey & mask];
@@ -307,8 +308,17 @@ void clear_histories(void) {
     }
     
     for (int i = 0; i < thread_pool.shared_history_count; i++) {
-        free(thread_pool.shared_histories[i]);
-        thread_pool.shared_histories[i] = (SharedHistory *)calloc(1, sizeof(SharedHistory));
+        SharedHistory *sh = thread_pool.shared_histories[i];
+        memset(sh->contCorrhist, 0, (sh->cont_mask + 1) * sizeof(int16_t));
+        for (int c = 0; c < 2; c++) {
+            memset(sh->pawn_corrhist[c], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));
+            memset(sh->minor_corrhist[c], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));
+            memset(sh->major_corrhist[c], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));
+            memset(sh->krp_corrhist[c], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));
+            for (int c2 = 0; c2 < 2; c2++) {
+                memset(sh->non_pawn_corrhist[c][c2], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));
+            }
+        }
     }
     
     int threads_per_l3 = 8;

--- a/src/history.c
+++ b/src/history.c
@@ -22,7 +22,7 @@ int CORRHIST_WEIGHT_SCALE = 256;
 int CORRHIST_GRAIN = 256;
 int CORRHIST_LIMIT = 1024;
 int BASE_CORRHIST_SIZE = 16384;
-int BASE_CONT_CORRHIST_SIZE = 262144;
+int BASE_CONT_CORRHIST_SIZE = 1048576;
 int CORRHIST_MAX = 16384;
 
 /* Update History */
@@ -204,53 +204,40 @@ void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int di
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
-void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight, SearchStack *ss) {
+void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight) {
     if (t->pos.ply < pliesBack) return;
-    SearchStack *prev = ss - pliesBack;
 
-    const int m1 = prev->move;
-    const int m2 = ss->move;
-    
-    if (m1 && m2) {
-        uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
-        int16_t *entry_ptr = &t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
-                
-        int val = *entry_ptr;
-        val = (val * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
-                
-        if (val > CORRHIST_MAX) val = CORRHIST_MAX;
-        else if (val < -CORRHIST_MAX) val = -CORRHIST_MAX;
+    uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
+    int16_t *entry_ptr = &t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
+            
+    int val = *entry_ptr;
+    val = (val * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
+            
+    if (val > CORRHIST_MAX) val = CORRHIST_MAX;
+    else if (val < -CORRHIST_MAX) val = -CORRHIST_MAX;
 
-        *entry_ptr = (int16_t)val;
-    }
+    *entry_ptr = (int16_t)val;
 }
 
-static inline int adjust_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, SearchStack *ss) {
+static inline int adjust_single_cont_corrhist_entry(ThreadData *t, const int pliesBack) {
     if (t->pos.ply < pliesBack) return 0;
-    SearchStack *prev = ss - pliesBack;
-
-    const int m1 = prev->move;
-    const int m2 = ss->move;
-
-    if (m1 && m2) {
-        uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
-        return t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
-    }
-    return 0;
+    
+    uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
+    return t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
 }
 
-void update_continuation_corrhist(ThreadData *t, const int depth, const int diff, SearchStack *ss) {
+void update_continuation_corrhist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
 
-    update_single_cont_corrhist_entry(t, 1, scaledDiff, newWeight, ss);
-    update_single_cont_corrhist_entry(t, 2, scaledDiff, newWeight, ss);
-    update_single_cont_corrhist_entry(t, 3, scaledDiff, newWeight, ss);
-    update_single_cont_corrhist_entry(t, 4, scaledDiff, newWeight, ss);
-    update_single_cont_corrhist_entry(t, 5, scaledDiff, newWeight, ss);
+    update_single_cont_corrhist_entry(t, 1, scaledDiff, newWeight);
+    update_single_cont_corrhist_entry(t, 2, scaledDiff, newWeight);
+    update_single_cont_corrhist_entry(t, 3, scaledDiff, newWeight);
+    update_single_cont_corrhist_entry(t, 4, scaledDiff, newWeight);
+    update_single_cont_corrhist_entry(t, 5, scaledDiff, newWeight);
 }
 
-int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {       
+int adjust_eval_with_corrhist(ThreadData *t, int rawEval) {       
     rawEval = (rawEval * (300 - t->pos.fifty)) / 300;
     
     const int side = t->pos.side;
@@ -263,11 +250,11 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {
                + t->shared_history->krp_corrhist[side][t->pos.krpKey & mask]
                + t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask]
                + t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask]
-               + adjust_single_cont_corrhist_entry(t, 1, ss)
-               + adjust_single_cont_corrhist_entry(t, 2, ss)
-               + adjust_single_cont_corrhist_entry(t, 3, ss)               
-               + adjust_single_cont_corrhist_entry(t, 4, ss)
-               + adjust_single_cont_corrhist_entry(t, 5, ss);
+               + adjust_single_cont_corrhist_entry(t, 1)
+               + adjust_single_cont_corrhist_entry(t, 2)
+               + adjust_single_cont_corrhist_entry(t, 3)               
+               + adjust_single_cont_corrhist_entry(t, 4)
+               + adjust_single_cont_corrhist_entry(t, 5);
 
     const int mateFound = mateValue - maxPly;
     
@@ -279,7 +266,7 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {
     return rawEval;
 }
 
-int get_correction_value(ThreadData *t, SearchStack *ss) {
+int get_correction_value(ThreadData *t) {
     const int side = t->pos.side;
     const int mask = t->shared_history->corrhist_mask;
 
@@ -289,7 +276,7 @@ int get_correction_value(ThreadData *t, SearchStack *ss) {
     const int krp_correction = t->shared_history->krp_corrhist[side][t->pos.krpKey & mask];
     const int white_non_pawn_correction = t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
     const int black_non_pawn_correction = t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask];
-    const int continuation_correction = adjust_single_cont_corrhist_entry(t, 2, ss);
+    const int continuation_correction = adjust_single_cont_corrhist_entry(t, 2);
     
     int correction = pawn_correction + minor_correction + major_correction +
                     krp_correction + white_non_pawn_correction + black_non_pawn_correction +

--- a/src/history.c
+++ b/src/history.c
@@ -22,7 +22,6 @@ int CORRHIST_WEIGHT_SCALE = 256;
 int CORRHIST_GRAIN = 256;
 int CORRHIST_LIMIT = 1024;
 int BASE_CORRHIST_SIZE = 16384;
-int BASE_CONT_CORRHIST_SIZE = 1048576;
 int CORRHIST_MAX = 16384;
 
 /* Update History */
@@ -204,40 +203,53 @@ void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int di
     apply_corrhist_update(entry, scaledDiff, newWeight);
 }
 
-void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight) {
+void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight, SearchStack *ss) {
     if (t->pos.ply < pliesBack) return;
+    SearchStack *prev = ss - pliesBack;
 
-    uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
-    int16_t *entry_ptr = &t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
-            
-    int val = *entry_ptr;
-    val = (val * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
-            
-    if (val > CORRHIST_MAX) val = CORRHIST_MAX;
-    else if (val < -CORRHIST_MAX) val = -CORRHIST_MAX;
-
-    *entry_ptr = (int16_t)val;
-}
-
-static inline int adjust_single_cont_corrhist_entry(ThreadData *t, const int pliesBack) {
-    if (t->pos.ply < pliesBack) return 0;
+    const int m1 = prev->move;
+    const int m2 = ss->move;
     
-    uint64_t diff_key = t->pos.hashKey ^ t->pos.repetitionTable[t->pos.repetitionIndex - pliesBack + 1];
-    return t->shared_history->contCorrhist[diff_key & t->shared_history->cont_mask];
+    if (m1 && m2) {
+        int16_t *entry_ptr = &t->shared_history->contCorrhist[prev->piece][getMoveTarget(m1)]
+                                         [ss->piece][getMoveTarget(m2)];
+                
+        int val = *entry_ptr;
+        val = (val * (CORRHIST_WEIGHT_SCALE - newWeight) + scaledDiff * newWeight) / CORRHIST_WEIGHT_SCALE;
+                
+        if (val > CORRHIST_MAX) val = CORRHIST_MAX;
+        else if (val < -CORRHIST_MAX) val = -CORRHIST_MAX;
+
+        *entry_ptr = (int16_t)val;
+    }
 }
 
-void update_continuation_corrhist(ThreadData *t, const int depth, const int diff) {
+static inline int adjust_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, SearchStack *ss) {
+    if (t->pos.ply < pliesBack) return 0;
+    SearchStack *prev = ss - pliesBack;
+
+    const int m1 = prev->move;
+    const int m2 = ss->move;
+
+    if (m1 && m2) {
+        return t->shared_history->contCorrhist[prev->piece][getMoveTarget(m1)]
+                               [ss->piece][getMoveTarget(m2)];
+    }
+    return 0;
+}
+
+void update_continuation_corrhist(ThreadData *t, const int depth, const int diff, SearchStack *ss) {
     const int scaledDiff = diff * CORRHIST_GRAIN;
     const int newWeight = 4 * myMIN(depth + 1, 16);
 
-    update_single_cont_corrhist_entry(t, 1, scaledDiff, newWeight);
-    update_single_cont_corrhist_entry(t, 2, scaledDiff, newWeight);
-    update_single_cont_corrhist_entry(t, 3, scaledDiff, newWeight);
-    update_single_cont_corrhist_entry(t, 4, scaledDiff, newWeight);
-    update_single_cont_corrhist_entry(t, 5, scaledDiff, newWeight);
+    update_single_cont_corrhist_entry(t, 1, scaledDiff, newWeight, ss);
+    update_single_cont_corrhist_entry(t, 2, scaledDiff, newWeight, ss);
+    update_single_cont_corrhist_entry(t, 3, scaledDiff, newWeight, ss);
+    update_single_cont_corrhist_entry(t, 4, scaledDiff, newWeight, ss);
+    update_single_cont_corrhist_entry(t, 5, scaledDiff, newWeight, ss);
 }
 
-int adjust_eval_with_corrhist(ThreadData *t, int rawEval) {       
+int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {       
     rawEval = (rawEval * (300 - t->pos.fifty)) / 300;
     
     const int side = t->pos.side;
@@ -250,11 +262,11 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval) {
                + t->shared_history->krp_corrhist[side][t->pos.krpKey & mask]
                + t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask]
                + t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask]
-               + adjust_single_cont_corrhist_entry(t, 1)
-               + adjust_single_cont_corrhist_entry(t, 2)
-               + adjust_single_cont_corrhist_entry(t, 3)               
-               + adjust_single_cont_corrhist_entry(t, 4)
-               + adjust_single_cont_corrhist_entry(t, 5);
+               + adjust_single_cont_corrhist_entry(t, 1, ss)
+               + adjust_single_cont_corrhist_entry(t, 2, ss)
+               + adjust_single_cont_corrhist_entry(t, 3, ss)               
+               + adjust_single_cont_corrhist_entry(t, 4, ss)
+               + adjust_single_cont_corrhist_entry(t, 5, ss);
 
     const int mateFound = mateValue - maxPly;
     
@@ -266,7 +278,7 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval) {
     return rawEval;
 }
 
-int get_correction_value(ThreadData *t) {
+int get_correction_value(ThreadData *t, SearchStack *ss) {
     const int side = t->pos.side;
     const int mask = t->shared_history->corrhist_mask;
 
@@ -276,7 +288,7 @@ int get_correction_value(ThreadData *t) {
     const int krp_correction = t->shared_history->krp_corrhist[side][t->pos.krpKey & mask];
     const int white_non_pawn_correction = t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
     const int black_non_pawn_correction = t->shared_history->non_pawn_corrhist[black][side][t->pos.blackNonPawnKey & mask];
-    const int continuation_correction = adjust_single_cont_corrhist_entry(t, 2);
+    const int continuation_correction = adjust_single_cont_corrhist_entry(t, 2, ss);
     
     int correction = pawn_correction + minor_correction + major_correction +
                     krp_correction + white_non_pawn_correction + black_non_pawn_correction +
@@ -296,7 +308,8 @@ void clear_histories(void) {
     
     for (int i = 0; i < thread_pool.shared_history_count; i++) {
         SharedHistory *sh = thread_pool.shared_histories[i];
-        memset(sh->contCorrhist, 0, (sh->cont_mask + 1) * sizeof(int16_t));
+        memset(sh->pawnHistory, 0, sizeof(sh->pawnHistory));
+        memset(sh->contCorrhist, 0, sizeof(sh->contCorrhist));
         for (int c = 0; c < 2; c++) {
             memset(sh->pawn_corrhist[c], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));
             memset(sh->minor_corrhist[c], 0, (sh->corrhist_mask + 1) * sizeof(int16_t));

--- a/src/history.h
+++ b/src/history.h
@@ -46,11 +46,11 @@ void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff)
 void update_minor_correction_hist(ThreadData *t, const int depth, const int diff);
 void update_major_correction_hist(ThreadData *t, const int depth, const int diff);
 void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff);
-void update_continuation_corrhist(ThreadData *t, const int depth, const int diff);
-void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight);
+void update_continuation_corrhist(ThreadData *t, const int depth, const int diff, SearchStack *ss);
+void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight, SearchStack *ss);
 void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int diff);
-int adjust_eval_with_corrhist(ThreadData *t, int rawEval);
-int get_correction_value(ThreadData *t);
+int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss);
+int get_correction_value(ThreadData *t, SearchStack *ss);
 void clear_histories(void);
 void quiet_history_aging(void);
 

--- a/src/history.h
+++ b/src/history.h
@@ -25,7 +25,8 @@ enum {
 extern int CORRHIST_WEIGHT_SCALE;
 extern int CORRHIST_GRAIN;
 extern int CORRHIST_LIMIT;
-extern int CORRHIST_SIZE;
+extern int BASE_CORRHIST_SIZE;
+extern int BASE_CONT_CORRHIST_SIZE;
 extern int CORRHIST_MAX;
 extern int BAD_QUIET_INDEX_SCALE;
 

--- a/src/history.h
+++ b/src/history.h
@@ -46,11 +46,11 @@ void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff)
 void update_minor_correction_hist(ThreadData *t, const int depth, const int diff);
 void update_major_correction_hist(ThreadData *t, const int depth, const int diff);
 void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff);
-void update_continuation_corrhist(ThreadData *t, const int depth, const int diff, SearchStack *ss);
-void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight, SearchStack *ss);
+void update_continuation_corrhist(ThreadData *t, const int depth, const int diff);
+void update_single_cont_corrhist_entry(ThreadData *t, const int pliesBack, const int scaledDiff, const int newWeight);
 void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int diff);
-int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss);
-int get_correction_value(ThreadData *t, SearchStack *ss);
+int adjust_eval_with_corrhist(ThreadData *t, int rawEval);
+int get_correction_value(ThreadData *t);
 void clear_histories(void);
 void quiet_history_aging(void);
 

--- a/src/search.c
+++ b/src/search.c
@@ -696,7 +696,7 @@ int quiescence(int alpha, int beta, ThreadData *t, my_time* time, SearchStack *s
     // evaluate position
     int evaluation = evaluate(position);
 
-    evaluation = adjust_eval_with_corrhist(t, evaluation);
+    evaluation = adjust_eval_with_corrhist(t, evaluation, ss);
 
     score = bestScore = tt_hit ? tt_score : evaluation;
 
@@ -922,14 +922,14 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
     // get static evaluation score
     int raw_eval = evaluate(pos);
 
-    int static_eval = adjust_eval_with_corrhist(t, raw_eval);
+    int static_eval = adjust_eval_with_corrhist(t, raw_eval, ss);
 
     bool improving = false;
     bool tt_capture = tt_move && getMoveCapture(tt_move);
 
     bool corrplexity = abs(raw_eval - static_eval) > 82;
     int corrplexity_value = abs(raw_eval - static_eval);
-    int correction_value = get_correction_value(t);    
+    int correction_value = get_correction_value(t, ss);    
 
     ss->staticEval = static_eval;    
 
@@ -1708,7 +1708,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             update_minor_correction_hist(t, depth, corrhistBonus);
             update_major_correction_hist(t, depth, corrhistBonus);
             update_non_pawn_corrhist(t, depth, corrhistBonus);
-            update_continuation_corrhist(t, depth, corrhistBonus);
+            update_continuation_corrhist(t, depth, corrhistBonus, ss);
             update_king_rook_pawn_corrhist(t, depth, corrhistBonus);
         }
 

--- a/src/search.c
+++ b/src/search.c
@@ -696,7 +696,7 @@ int quiescence(int alpha, int beta, ThreadData *t, my_time* time, SearchStack *s
     // evaluate position
     int evaluation = evaluate(position);
 
-    evaluation = adjust_eval_with_corrhist(t, evaluation, ss);
+    evaluation = adjust_eval_with_corrhist(t, evaluation);
 
     score = bestScore = tt_hit ? tt_score : evaluation;
 
@@ -922,14 +922,14 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
     // get static evaluation score
     int raw_eval = evaluate(pos);
 
-    int static_eval = adjust_eval_with_corrhist(t, raw_eval, ss);
+    int static_eval = adjust_eval_with_corrhist(t, raw_eval);
 
     bool improving = false;
     bool tt_capture = tt_move && getMoveCapture(tt_move);
 
     bool corrplexity = abs(raw_eval - static_eval) > 82;
     int corrplexity_value = abs(raw_eval - static_eval);
-    int correction_value = get_correction_value(t, ss);    
+    int correction_value = get_correction_value(t);    
 
     ss->staticEval = static_eval;    
 
@@ -1708,7 +1708,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             update_minor_correction_hist(t, depth, corrhistBonus);
             update_major_correction_hist(t, depth, corrhistBonus);
             update_non_pawn_corrhist(t, depth, corrhistBonus);
-            update_continuation_corrhist(t, depth, corrhistBonus, ss);
+            update_continuation_corrhist(t, depth, corrhistBonus);
             update_king_rook_pawn_corrhist(t, depth, corrhistBonus);
         }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -206,8 +206,8 @@ typedef struct {
     // pawnHistory [pawnKey][piece][to]
     int16_t pawnHistory[2048][12][64];
 
-    // continuationCorrectionHistory Zobrist based 1D array
-    int16_t *contCorrhist;
+    // continuationCorrectionHistory 4D array
+    int16_t contCorrhist[12][64][12][64];
 
     // pawn correction history [side to move]
     int16_t *pawn_corrhist[2];
@@ -225,7 +225,6 @@ typedef struct {
     int16_t *krp_corrhist[2];
     
     int corrhist_mask;
-    int cont_mask;
 } SharedHistory;
 
 typedef struct {

--- a/src/structs.h
+++ b/src/structs.h
@@ -206,23 +206,26 @@ typedef struct {
     // pawnHistory [pawnKey][piece][to]
     int16_t pawnHistory[2048][12][64];
 
-    // continuationCorrectionHistory[previousPiece][previousTargetSq][currentPiece][currentTargetSq]
-    int16_t contCorrhist[12][64][12][64];
+    // continuationCorrectionHistory Zobrist based 1D array
+    int16_t *contCorrhist;
 
-    // pawn correction history [side to move][key]
-    int16_t pawn_corrhist[2][16384];
+    // pawn correction history [side to move]
+    int16_t *pawn_corrhist[2];
 
-    // minor correction history [side to move][key]
-    int16_t minor_corrhist[2][16384];
+    // minor correction history [side to move]
+    int16_t *minor_corrhist[2];
 
-    // major correction history [side to move][key]
-    int16_t major_corrhist[2][16384];
+    // major correction history [side to move]
+    int16_t *major_corrhist[2];
 
-    // non pawn correction history [side to move][key]
-    int16_t non_pawn_corrhist[2][2][16384];
+    // non pawn correction history [side to move]
+    int16_t *non_pawn_corrhist[2][2];
 
-    // king rook pawn correction history [side to move][key]
-    int16_t krp_corrhist[2][16384];
+    // king rook pawn correction history [side to move]
+    int16_t *krp_corrhist[2];
+    
+    int corrhist_mask;
+    int cont_mask;
 } SharedHistory;
 
 typedef struct {

--- a/src/table.c
+++ b/src/table.c
@@ -220,7 +220,7 @@ void prefetch_hash_entry(uint64_t hash_key, uint8_t fmr_key) {
 }
 
 void prefetch_corrhist(board *pos, ThreadData *t) { 
-    const int mask = CORRHIST_SIZE - 1;
+    const int mask = t->shared_history->corrhist_mask;
     const int side = pos->side;
 
     __builtin_prefetch(&t->shared_history->pawn_corrhist[side][pos->pawnKey & mask]);

--- a/src/threads.c
+++ b/src/threads.c
@@ -4,6 +4,8 @@
 
 #include "threads.h"
 #include "search.h"
+#include "utils.h"
+#include "history.h"
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -33,7 +35,18 @@ static void free_threads(void) {
 
     for (int i = 0; i < thread_pool.shared_history_count; i++) {
         if (thread_pool.shared_histories[i] != NULL) {
-            free(thread_pool.shared_histories[i]);
+            SharedHistory *sh = thread_pool.shared_histories[i];
+            free(sh->contCorrhist);
+            for (int c = 0; c < 2; c++) {
+                free(sh->pawn_corrhist[c]);
+                free(sh->minor_corrhist[c]);
+                free(sh->major_corrhist[c]);
+                free(sh->krp_corrhist[c]);
+                for (int c2 = 0; c2 < 2; c2++) {
+                    free(sh->non_pawn_corrhist[c][c2]);
+                }
+            }
+            free(sh);
             thread_pool.shared_histories[i] = NULL;
         }
     }
@@ -61,9 +74,29 @@ void init_threads(int requested_count) {
 
     for (int i = 0; i < thread_pool.shared_history_count; i++) {
         thread_pool.shared_histories[i] = (SharedHistory *)calloc(1, sizeof(SharedHistory));
-        // Note: calloc allocates zeroed memory lazily. The physical RAM pages will only be
-        // allocated when the threads first write to them during search, perfectly assigning
-        // the memory to their local NUMA node!
+        SharedHistory *sh = thread_pool.shared_histories[i];
+        
+        int local_threads = requested_count - (i * threads_per_l3);
+        if (local_threads > threads_per_l3) local_threads = threads_per_l3;
+        
+        int scale = next_power_of_2(local_threads);
+        int corrhist_size = BASE_CORRHIST_SIZE * scale;
+        int cont_size = BASE_CONT_CORRHIST_SIZE * scale;
+        
+        sh->corrhist_mask = corrhist_size - 1;
+        sh->cont_mask = cont_size - 1;
+        
+        sh->contCorrhist = (int16_t *)calloc(cont_size, sizeof(int16_t));
+        
+        for (int c = 0; c < 2; c++) {
+            sh->pawn_corrhist[c] = (int16_t *)calloc(corrhist_size, sizeof(int16_t));
+            sh->minor_corrhist[c] = (int16_t *)calloc(corrhist_size, sizeof(int16_t));
+            sh->major_corrhist[c] = (int16_t *)calloc(corrhist_size, sizeof(int16_t));
+            sh->krp_corrhist[c] = (int16_t *)calloc(corrhist_size, sizeof(int16_t));
+            for (int c2 = 0; c2 < 2; c2++) {
+                sh->non_pawn_corrhist[c][c2] = (int16_t *)calloc(corrhist_size, sizeof(int16_t));
+            }
+        }
     }
 
     for (int i = 0; i < requested_count; i++) {

--- a/src/threads.c
+++ b/src/threads.c
@@ -36,7 +36,6 @@ static void free_threads(void) {
     for (int i = 0; i < thread_pool.shared_history_count; i++) {
         if (thread_pool.shared_histories[i] != NULL) {
             SharedHistory *sh = thread_pool.shared_histories[i];
-            free(sh->contCorrhist);
             for (int c = 0; c < 2; c++) {
                 free(sh->pawn_corrhist[c]);
                 free(sh->minor_corrhist[c]);
@@ -81,12 +80,7 @@ void init_threads(int requested_count) {
         
         int scale = next_power_of_2(local_threads);
         int corrhist_size = BASE_CORRHIST_SIZE * scale;
-        int cont_size = BASE_CONT_CORRHIST_SIZE * scale;
-        
         sh->corrhist_mask = corrhist_size - 1;
-        sh->cont_mask = cont_size - 1;
-        
-        sh->contCorrhist = (int16_t *)calloc(cont_size, sizeof(int16_t));
         
         for (int c = 0; c < 2; c++) {
             sh->pawn_corrhist[c] = (int16_t *)calloc(corrhist_size, sizeof(int16_t));

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.42.91"
+#define VERSION "3.43.91"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -193,3 +193,13 @@ void print_info(ThreadData *t, int depth, int score, int totalTime) {
     }
     printf("\n");
 }
+
+uint32_t next_power_of_2(uint32_t x) {
+    x--;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    return x + 1;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,5 +34,6 @@ void printMailbox(const board *position);
 char* get_move_string(uint16_t move);
 int clamp(const int d, const int min, const int max);
 void print_info(ThreadData *t, int depth, int score, int totalTime);
+uint32_t next_power_of_2(uint32_t x);
 
 #endif //POTENTIAL_UTILS_H


### PR DESCRIPTION
```
Elo   | -5.32 +- 11.03 (95%)
SPRT  | 5.0+0.05s Threads=4 Hash=128MB
LLR   | -1.17 (-2.94, 2.94) [0.00, 7.50]
Games | N: 1568 W: 397 L: 421 D: 750
Penta | [35, 201, 329, 191, 28]
```
https://rektdie.pythonanywhere.com/test/4855/

```
Elo   | 11.73 +- 7.11 (95%)
SPRT  | 20.0+0.20s Threads=8 Hash=256MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 7.50]
Games | N: 2666 W: 678 L: 588 D: 1400
Penta | [14, 283, 654, 363, 19]
```
https://rektdie.pythonanywhere.com/test/4856/

bench: 17142319