### PR TITLE
refactor and improve the time management

### DIFF
--- a/src/datagen.c
+++ b/src/datagen.c
@@ -174,7 +174,7 @@ int play_selfgen_game(FILE *out_file, FILE *illegal_file, int nodes_limit, int u
 
         FenString fen_str = get_fen(&pos);
 
-        resetTimeControl(&time);
+        initTimeControl(&time);
         time.isNodeLimit = 1;
         time.node_limit = nodes_limit;
         time.is_datagen = true;

--- a/src/search.c
+++ b/src/search.c
@@ -1774,33 +1774,16 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
         t->pos.rootDepth = current_depth;
 
 
-        int startTime = getTimeMiliSecond();
-
-        if (time->is_datagen) {
-            check_node_limit(time, t);
-        } else {
-            if (t->id == 0 && ((time->timeset && startTime >= time->softLimit) || (time->isNodeLimit && total_nodes() >= time->node_limit)) && t->pos.pvTable[0][0] != 0) {
-                time->stopped = 1;
-                store_rlx(thread_pool.stop, true);
-            } else if (load_rlx(thread_pool.stop)) {
-                time->stopped = 1;
-            }
-        }
+        int startTime = getTimeMiliSecond();        
 
         int window = ASP_WINDOW_BASE;
         int aspirationWindowDepth = current_depth;
 
         while (true) {
 
-            if (time->is_datagen) {
-                check_node_limit(time, t);
-            } else {
-                if (t->id == 0 && ((time->timeset && startTime >= time->softLimit) || (time->isNodeLimit && total_nodes() >= time->node_limit)) && t->pos.pvTable[0][0] != 0) {
-                    time->stopped = 1;
-                    store_rlx(thread_pool.stop, true);
-                } else if (load_rlx(thread_pool.stop)) {
-                    time->stopped = 1;
-                }
+            // check time and node limits (the check should done by the main thread)
+            if (t->id == 0) {
+                check_time_limit(time, startTime, t, score);
             }
 
             if (time->stopped == 1) {
@@ -1888,7 +1871,7 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
         int endTime = getTimeMiliSecond();
         totalTime += endTime - startTime;
 
-        if (t->id == 0 && t->pos.pvLength[0] && !benchmark) {
+        if (t->id == 0 && t->pos.pvLength[0] && !benchmark && !time->stopped) {
             print_info(t, current_depth, score, totalTime);
         }
 

--- a/src/timeman.c
+++ b/src/timeman.c
@@ -21,22 +21,24 @@ void initTimeControl(my_time* time) {
     time->is_datagen = false;
 }
 
-// reset time control variables
-void resetTimeControl(my_time* time) {
-    // reset timing
-    time->quit = 0;
-    time->isNodeLimit = false;
-    time->movestogo = 20;
-    time->movetime = -1;
-    time->time = -1;
-    time->inc = 0;
-    time->starttime = 0;
-    time->stoptime = 0;
-    time->timeset = 0;
-    time->stopped = 0;
-    time->softLimit = 0;
-    time->hardLimit = 0;
-    time->is_datagen = false;
+
+void check_time_limit(my_time *time, int startTime, ThreadData *t, int score) {
+    if (time->is_datagen) {
+        check_node_limit(time, t);
+    } else {
+        // the search must contain a best move
+        if (t->pos.pvTable[0][0] != 0) {
+            if (((time->timeset && startTime >= time->softLimit) || (time->isNodeLimit && total_nodes() >= time->node_limit))) {
+                time->stopped = 1;
+                store_rlx(thread_pool.stop, true);
+            } else if (score >= mateValue - 3 || score == -mateValue + 2) {
+                time->stopped = 1;
+                store_rlx(thread_pool.stop, true);
+            } else if (load_rlx(thread_pool.stop)) {
+                time->stopped = 1;
+            }
+        }        
+    }
 }
 
 int getTimeMiliSecond(void) {

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "structs.h"
+#include "threads.h"
+#include "values.h"
 
 #ifdef WIN64
 
@@ -20,9 +22,10 @@
 #endif
 
 void initTimeControl(my_time* time);
-void resetTimeControl(my_time* time);
+
 int getTimeMiliSecond();
 int input_waiting();
+void check_time_limit(my_time *time, int startTime, ThreadData *t, int score);
 
 
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -19,7 +19,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.43.91"
+#define VERSION "3.44.91"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 
@@ -173,7 +173,7 @@ void parse_position(char *command, board* position) {
 void goCommand(char *command, ThreadData *t, board* root_pos, my_time* time) {
 
     // reset time control
-    resetTimeControl(time);
+    initTimeControl(time);
 
     // init parameters
     int depth = -1;


### PR DESCRIPTION
In a recent event at CCC, Stockfish lost time while constantly calculating checkmate in 1 or 2 moves from depth 1 to depth 250 with very low time.

To prevent this, if we find a checkmate in one or two moves, we can immediately stop the search without any problem and print the best move and information.

the patch idea from: @robertnurnberg

Also zero seldepth at the last iteration fixed.

```
Elo   | 2.87 +- 5.96 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=32MB
LLR   | 3.08 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 6300 W: 1986 L: 1934 D: 2380
Penta | [198, 696, 1314, 740, 202]
```
https://rektdie.pythonanywhere.com/test/4879/

bench: 17142319