### PR TITLE
do setwise attacks (aka Kogge Stone Algorithm)

### DIFF
--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -219,6 +219,156 @@ void init_tables() {
     }
 }
 
+#define FILE_A_BB 0x0101010101010101ULL
+#define FILE_B_BB (FILE_A_BB << 1)
+#define FILE_G_BB (FILE_A_BB << 6)
+#define FILE_H_BB (FILE_A_BB << 7)
+#define RANK_TOP_BB 0xffULL
+#define RANK_BOT_BB (0xffULL << 56)
+
+#if defined(USE_AVX512)
+
+#include <immintrin.h>
+
+typedef uint64_t u64x8 __attribute__((__vector_size__(8 * sizeof(uint64_t))));
+
+static inline u64x8 rotl_u64x8(u64x8 x, u64x8 s) {
+  return (u64x8)_mm512_rolv_epi64((__m512i)x, (__m512i)s);
+}
+
+static inline uint64_t knight_threats_setwise(uint64_t knights) {
+  const u64x8 shifts = {6, 15, 17, 10, 64 - 6, 64 - 15, 64 - 17, 64 - 10};
+  const u64x8 masks = {
+      FILE_A_BB | FILE_B_BB | RANK_BOT_BB,
+      FILE_A_BB | (RANK_BOT_BB >> 8) | RANK_BOT_BB,
+      FILE_H_BB | (RANK_BOT_BB >> 8) | RANK_BOT_BB,
+      FILE_G_BB | FILE_H_BB | RANK_BOT_BB,
+      FILE_G_BB | FILE_H_BB | RANK_TOP_BB,
+      FILE_H_BB | RANK_TOP_BB | (RANK_TOP_BB << 8),
+      FILE_A_BB | RANK_TOP_BB | (RANK_TOP_BB << 8),
+      FILE_A_BB | FILE_B_BB | RANK_TOP_BB,
+  };
+  u64x8 g = {knights, knights, knights, knights,
+             knights, knights, knights, knights};
+  g = rotl_u64x8(g & ~masks, shifts);
+  g |= __builtin_shufflevector(g, g, 4, 5, 6, 7, 0, 1, 2, 3);
+  g |= __builtin_shufflevector(g, g, 2, 3, 0, 1, 6, 7, 4, 5);
+  g |= __builtin_shufflevector(g, g, 1, 0, 3, 2, 5, 4, 7, 6);
+  return g[0];
+}
+
+static inline void slider_threats_setwise(uint64_t orthogonal,
+                                          uint64_t diagonal,
+                                          uint64_t blockers,
+                                          uint64_t *orthogonal_threats,
+                                          uint64_t *diagonal_threats) {
+  const u64x8 edge = {
+      FILE_A_BB | RANK_BOT_BB, FILE_H_BB | RANK_BOT_BB,
+      FILE_H_BB | RANK_TOP_BB, FILE_A_BB | RANK_TOP_BB,
+      FILE_A_BB,               RANK_BOT_BB,
+      FILE_H_BB,               RANK_TOP_BB,
+  };
+  //                v----diagonals-----v  v----orthogonals----v
+  const u64x8 r1 = {64 - 7, 64 - 9, 7, 9, 1, 64 - 8,  64 - 1, 8};
+  const u64x8 r2 = r1 * 2 % 64; // % 64 to wrap the negative shifts
+  const u64x8 r4 = r2 * 2 % 64;
+
+  u64x8 g   = {diagonal,   diagonal,   diagonal,   diagonal,
+               orthogonal, orthogonal, orthogonal, orthogonal};
+  u64x8 blk = {blockers,   blockers,   blockers,   blockers,
+               blockers,   blockers,   blockers,   blockers};
+  blk |= edge;
+
+  // kogge stone flood fill, never overlaps blockers
+  g   |= ~blk & rotl_u64x8(g, r1);
+  blk |= rotl_u64x8(blk, r1);
+
+  g   |= ~blk & rotl_u64x8(g, r2);
+  blk |= rotl_u64x8(blk, r2);
+
+  g   |= ~blk & rotl_u64x8(g, r4);
+
+  // add in the actual attacks, but dont go past the edge
+  // hits all the blockers
+  g    = ~edge & rotl_u64x8(g, r1);
+
+  g |= __builtin_shufflevector(g, g, 2, 3, 0, 1, 6, 7, 4, 5);
+  g |= __builtin_shufflevector(g, g, 1, 0, 3, 2, 5, 4, 7, 6);
+  *diagonal_threats   = g[0];
+  *orthogonal_threats = g[4];
+}
+
+#else
+
+typedef uint64_t u64x4 __attribute__((__vector_size__(4 * sizeof(uint64_t))));
+
+static inline uint64_t knight_threats_setwise(uint64_t knights) {
+  const u64x4 shifts = {6, 15, 17, 10};
+  const u64x4 masks_left = {
+      FILE_A_BB | FILE_B_BB | RANK_BOT_BB,
+      FILE_A_BB | (RANK_BOT_BB >> 8) | RANK_BOT_BB,
+      FILE_H_BB | (RANK_BOT_BB >> 8) | RANK_BOT_BB,
+      FILE_G_BB | FILE_H_BB | RANK_BOT_BB,
+  };
+  const u64x4 masks_right = {
+      FILE_G_BB | FILE_H_BB | RANK_TOP_BB,
+      FILE_H_BB | RANK_TOP_BB | (RANK_TOP_BB << 8),
+      FILE_A_BB | RANK_TOP_BB | (RANK_TOP_BB << 8),
+      FILE_A_BB | FILE_B_BB | RANK_TOP_BB,
+  };
+  const u64x4 k = {knights, knights, knights, knights};
+  u64x4 g = ((k & ~masks_left) << shifts) | ((k & ~masks_right) >> shifts);
+  g |= __builtin_shufflevector(g, g, 2, 3, 0, 1);
+  g |= __builtin_shufflevector(g, g, 1, 0, 3, 2);
+  return g[0];
+}
+
+static inline void slider_threats_setwise(uint64_t orthogonal,
+                                          uint64_t diagonal,
+                                          uint64_t blockers,
+                                          uint64_t *orthogonal_threats,
+                                          uint64_t *diagonal_threats) {
+  const u64x4 edge_left  = {FILE_H_BB | RANK_TOP_BB, FILE_A_BB | RANK_TOP_BB,
+                            FILE_A_BB,               RANK_TOP_BB};
+  const u64x4 edge_right = {FILE_A_BB | RANK_BOT_BB, FILE_H_BB | RANK_BOT_BB,
+                            FILE_H_BB,               RANK_BOT_BB};
+  const u64x4 r1 = {7, 9, 1, 8};
+  const u64x4 r2 = r1 * 2;
+  const u64x4 r4 = r1 * 4;
+
+  u64x4 gl = {diagonal, diagonal, orthogonal, orthogonal};
+  u64x4 gr = gl;
+  u64x4 blkl = {blockers, blockers, blockers, blockers};
+  u64x4 blkr = blkl | edge_right;
+  blkl |= edge_left;
+
+  // kogge stone flood fill, never overlaps blockers
+  gl   |= ~blkl & (gl << r1);
+  gr   |= ~blkr & (gr >> r1);
+  blkl |= blkl << r1;
+  blkr |= blkr >> r1;
+
+  gl   |= ~blkl & (gl << r2);
+  gr   |= ~blkr & (gr >> r2);
+  blkl |= blkl << r2;
+  blkr |= blkr >> r2;
+
+  gl   |= ~blkl & (gl << r4);
+  gr   |= ~blkr & (gr >> r4);
+
+  // add in the actual attacks, but dont go past the edge
+  // hits all the blockers
+  gl = ~edge_left & (gl << r1);
+  gr = ~edge_right & (gr >> r1);
+
+  u64x4 g = gl | gr;
+  g |= __builtin_shufflevector(g, g, 1, 0, 3, 2);
+  *diagonal_threats   = g[0];
+  *orthogonal_threats = g[2];
+}
+
+#endif
+
 void get_threats(int side, board* pos) {
     uint64_t bb;
 
@@ -244,24 +394,17 @@ void get_threats(int side, board* pos) {
     kingBB = pos->bitboards[side == white ? k : K];
 
     // Calculate Knight attacks
-    pos->pieceThreats.knightThreats |= knight_threats(knightBB);
+    pos->pieceThreats.knightThreats |= knight_threats_setwise(knightBB);
     pos->pieceThreats.stmThreats[!pos->side] |= pos->pieceThreats.knightThreats;
 
-    // Calculate Bishop attacks
-    while (bishopBB) {
-        int bishopSquare = getLS1BIndex(bishopBB);
-        pos->pieceThreats.bishopThreats |= getBishopAttacks(bishopSquare, occupancies);
-        pos->pieceThreats.stmThreats[!pos->side] |= pos->pieceThreats.bishopThreats;
-        popBit(bishopBB, bishopSquare);
-    }
-
-    // Calculate Rook attacks
-    while (rookBB) {    
-        int rookSquare = getLS1BIndex(rookBB);
-        pos->pieceThreats.rookThreats |= getRookAttacks(rookSquare, occupancies);
-        pos->pieceThreats.stmThreats[!pos->side] |= pos->pieceThreats.rookThreats;
-        popBit(rookBB, rookSquare);
-    }
+    // Calculate Bishop & Rook attacks
+    uint64_t rook_attacks, bishop_attacks;
+    slider_threats_setwise(rookBB, bishopBB, occupancies, &rook_attacks,
+                           &bishop_attacks);
+    pos->pieceThreats.bishopThreats |= bishop_attacks;
+    pos->pieceThreats.stmThreats[!pos->side] |= pos->pieceThreats.bishopThreats;
+    pos->pieceThreats.rookThreats |= rook_attacks;
+    pos->pieceThreats.stmThreats[!pos->side] |= pos->pieceThreats.rookThreats;
 
     // Calculate Pawn attacks
     pos->pieceThreats.pawnThreats |= pawn_threats(pawnBB, !side);
@@ -301,24 +444,16 @@ U64 get_threats_bb(int side, board* pos) {
     kingBB = pos->bitboards[side == white ? K : k];
 
     // Calculate Knight attacks
-    threats |= knight_threats(knightBB);    
+    threats |= knight_threats_setwise(knightBB);
 
-    // Calculate Bishop attacks
-    while (bishopBB) {
-        int bishopSquare = getLS1BIndex(bishopBB);
-        threats |= getBishopAttacks(bishopSquare, pos->occupancies[both]);        
-        popBit(bishopBB, bishopSquare);
-    }
-
-    // Calculate Rook attacks
-    while (rookBB) {    
-        int rookSquare = getLS1BIndex(rookBB);
-        threats |= getRookAttacks(rookSquare, pos->occupancies[both]);        
-        popBit(rookBB, rookSquare);
-    }
+    // Calculate Bishop & Rook attacks
+    uint64_t rook_attacks, bishop_attacks;
+    slider_threats_setwise(rookBB, bishopBB, pos->occupancies[both],
+                           &rook_attacks, &bishop_attacks);
+    threats |= rook_attacks | bishop_attacks;
 
     // Calculate Pawn attacks
-    threats |= pawn_threats(pawnBB, side);    
+    threats |= pawn_threats(pawnBB, side);
     
     // Calculate Queen attacks
     while (queenBB) {

--- a/src/potential.c
+++ b/src/potential.c
@@ -4,7 +4,9 @@
 #include <unistd.h>
 #include <pthread.h>
 
-
+#ifndef __AVX2__
+#error "AVX2 is required but not supported by the target architecture."
+#endif
 
 #include "uci.h"
 #include "magic.h"

--- a/src/potential.c
+++ b/src/potential.c
@@ -20,7 +20,6 @@
 
 
 
-
 void initAll(void) {
     initLeaperAttacks();
     // init random keys for tranposition table

--- a/src/potential.c
+++ b/src/potential.c
@@ -4,9 +4,6 @@
 #include <unistd.h>
 #include <pthread.h>
 
-#ifndef __AVX2__
-#error "AVX2 is required but not supported by the target architecture."
-#endif
 
 #include "uci.h"
 #include "magic.h"


### PR DESCRIPTION
```
Elo   | -1.20 +- 4.48 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=32MB
LLR   | -2.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11866 W: 3705 L: 3746 D: 4415
Penta | [432, 1355, 2383, 1348, 415]
```
https://rektdie.pythonanywhere.com/test/4907/

our workers are so noisy

main:
<img width="151" height="399" alt="image" src="https://github.com/user-attachments/assets/273d8e3c-d2f6-4d28-9383-9bc57c9f8ade" />

the branch:
<img width="147" height="353" alt="image" src="https://github.com/user-attachments/assets/ed9979fc-a3f7-4d92-999a-3862a3716238" />

so it's clearly faster
bench: 17041598