### PR TITLE
every thread repeatedly age every threads own histories, fix that

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -339,14 +339,9 @@ void clear_histories(void) {
     }
 }
 
-void quiet_history_aging(void) {
-    int how_many_threads = thread_pool.thread_count;
-
-    for (int i = 0;i < how_many_threads;i++) {
-        int16_t *p = (int16_t *)thread_pool.threads[i]->search_d.quietHistory;
-
-        for (int j = 0; j < 32768; j++) {
-            p[j] >>= 1;
-        }
-    }            
+void quiet_history_aging(ThreadData *t) {
+    int16_t *p = (int16_t *)t->search_d.quietHistory;
+    for (int j = 0; j < 32768; j++) {
+        p[j] >>= 1;
+    }
 }

--- a/src/history.h
+++ b/src/history.h
@@ -63,7 +63,7 @@ void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int di
 int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss);
 int get_correction_value(ThreadData *t, SearchStack *ss);
 void clear_histories(void);
-void quiet_history_aging(void);
+void quiet_history_aging(ThreadData *t);
 
 
 #endif //POTENTIAL_HISTORY_H

--- a/src/search.c
+++ b/src/search.c
@@ -1838,7 +1838,7 @@ int searchPosition(int depth, bool benchmark, ThreadData *t, my_time* time) {
     uint8_t evalStability = 0;
     int baseSearchScore = -infinity;
 
-    quiet_history_aging();    
+    quiet_history_aging(t);    
 
     // iterative deepening
     for (int current_depth = 1; current_depth <= depth; current_depth++) {        

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.45.92"
+#define VERSION "3.45.93"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 6.86 +- 7.73 (95%)
SPRT  | 5.0+0.05s Threads=4 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 3342 W: 925 L: 859 D: 1558
Penta | [73, 394, 672, 458, 74]
```
https://rektdie.pythonanywhere.com/test/5046/

bench: 19490849