### PR TITLE
refactor razoring heuristic

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -203,7 +203,7 @@
   TUNE_INT RAZORING_TRIM = 1;
   TUNE_INT RAZORING_FULL_D = 2;
   TUNE_INT RAZORING_VERIFY_D = 3;
-  TUNE_INT RAZORING_MARGIN[] = {0, 100, 200, 300, 400};
+  TUNE_INT RAZORING_MARGIN = 100;
   
   
   /*╔═════════════════════╗
@@ -1147,36 +1147,28 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
     }    
 
     // razoring
-    if (!ss->singular_move &&
-        !pvNode && !in_check && depth <= RAZORING_DEPTH && tt_flag != hashFlagAlpha) {
-        int max_razor_index = 4;
-        int razor_depth = myMIN(myMIN(depth, RAZORING_DEPTH), max_razor_index);
+    const int razoring_margin = RAZORING_MARGIN * depth;
+    if (!ss->singular_move && !pvNode && !in_check && depth <= RAZORING_DEPTH && ttAdjustedEval + razoring_margin <= alpha && tt_flag != hashFlagAlpha) {
+        
+        const bool allow_full_razor = depth == 1 ||
+            (depth <= RAZORING_FULL_D && ttAdjustedEval + razoring_margin + RAZORING_FULL_MARGIN <= alpha);
 
-        if (razor_depth > 0) {
-            const int margin = RAZORING_MARGIN[razor_depth];
+        if (allow_full_razor) {
+            return quiescence(alpha, beta, t, time, ss);
+        }
 
-            if (ttAdjustedEval + margin <= alpha) {
-                const bool allow_full_razor = depth == 1 ||
-                (depth <= RAZORING_FULL_D && ttAdjustedEval + margin + RAZORING_FULL_MARGIN <= alpha);
+        const int capped_alpha = myMAX(alpha - razoring_margin, -mateValue);
+        const int razor_alpha = capped_alpha;
+        const int razor_beta = razor_alpha + 1;
+        int razor_score = quiescence(razor_alpha, razor_beta, t, time, ss);
 
-                if (allow_full_razor) {
-                    return quiescence(alpha, beta, t, time, ss);
-                }
+        // We proved a fail low.
+        if (razor_score <= razor_alpha) {                       
+            return razor_score;
+        }
 
-                const int capped_alpha = myMAX(alpha - margin, -mateValue);
-                const int razor_alpha = capped_alpha;
-                const int razor_beta = razor_alpha + 1;
-                int razor_score = quiescence(razor_alpha, razor_beta, t, time, ss);
-
-                // We proved a fail low.
-                if (razor_score <= razor_alpha) {                       
-                    return razor_score;
-                }
-
-                if (razor_score >= razor_beta + RAZORING_VERIFY_MARGIN && depth <= RAZORING_VERIFY_D) {                    
-                    depth -= myMIN(RAZORING_TRIM, depth - 1);
-                }
-            }
+        if (razor_score >= razor_beta + RAZORING_VERIFY_MARGIN && depth <= RAZORING_VERIFY_D) {                    
+            depth -= myMIN(RAZORING_TRIM, depth - 1);
         }
     }
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -20,7 +20,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.49.93"
+#define VERSION "3.49.94"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 0.31 +- 4.56 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 11344 W: 3635 L: 3625 D: 4084
Penta | [410, 1232, 2383, 1232, 415]
```
https://rektdie.pythonanywhere.com/test/5089/

bench: 19490849