### PR TITLE
depth 10 futility pruning and depth based quad margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1334,12 +1334,14 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
                 // Late Move Pruning
                 if (moves_seen >= lmpThreshold) {
                     continue;
-                }            
+                }
+                int sdepth = myMAX(0, depth - 5);
                 int futility_margin = 
                     static_eval + 
                     FUTILITY_PRUNING_OFFSET[clamp(lmrDepth, 1, 5)] + 
                     FP_MARGIN * lmrDepth + 
-                    (moveHistory * FP_HIST_MULT) / FP_HIST_DIVISOR;
+                    (moveHistory * FP_HIST_MULT) / FP_HIST_DIVISOR +                    
+                    sdepth * sdepth * 50;
                 
 
                 // Futility Pruning

--- a/src/search.c
+++ b/src/search.c
@@ -158,7 +158,7 @@
     ║ Futility Pruning   ║
     ╚════════════════════╝*/
   TUNE_INT FUTILITY_PRUNING_OFFSET[] = {0, 92, 47, 22, 11, 5};
-  TUNE_INT FP_DEPTH = 5;
+  TUNE_INT FP_DEPTH = 7;
   TUNE_INT FP_MARGIN = 71;
   TUNE_INT BNFP_MARGIN = 72;
   TUNE_INT QUIET_HISTORY_PRUNING_MARGIN = 1679;
@@ -1335,7 +1335,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
                 if (moves_seen >= lmpThreshold) {
                     continue;
                 }
-                int sdepth = myMAX(0, depth - 5);
+                int sdepth = myMAX(0, lmrDepth - 5);
                 int futility_margin = 
                     static_eval + 
                     FUTILITY_PRUNING_OFFSET[clamp(lmrDepth, 1, 5)] + 

--- a/src/search.c
+++ b/src/search.c
@@ -158,7 +158,7 @@
     ║ Futility Pruning   ║
     ╚════════════════════╝*/
   TUNE_INT FUTILITY_PRUNING_OFFSET[] = {0, 92, 47, 22, 11, 5};
-  TUNE_INT FP_DEPTH = 7;
+  TUNE_INT FP_DEPTH = 10;
   TUNE_INT FP_MARGIN = 71;
   TUNE_INT BNFP_MARGIN = 72;
   TUNE_INT QUIET_HISTORY_PRUNING_MARGIN = 1679;

--- a/src/uci.c
+++ b/src/uci.c
@@ -20,7 +20,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.49.94"
+#define VERSION "3.49.95"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 1.29 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.76 (-2.94, 2.94) [0.00, 5.00]
Games | N: 34862 W: 9780 L: 9651 D: 15431
Penta | [787, 4176, 7404, 4249, 815]
```
https://rektdie.pythonanywhere.com/test/5102/

```
Elo   | 3.50 +- 2.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20324 W: 5289 L: 5084 D: 9951
Penta | [248, 2365, 4735, 2562, 252]
```
https://rektdie.pythonanywhere.com/test/5104/

bench: 19455924

Credits: @JonathanHallstrom 
Thanks!