### PR TITLE
if tt score or beta decisive value then don't do failfirm

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -727,6 +727,10 @@ int get_draw_score(ThreadData *t) {
     return (load_rlx(t->search_i.nodes_searched) & 3) - 2; // Randomize between -2 and +2
 }
 
+int get_tt_cutoff_score(int tt_score, int beta) {
+    return tt_score >= beta && !is_decisive(tt_score) && !is_decisive(beta) ? (tt_score * 3 + beta) / 4 : tt_score;
+}
+
 // quiescence search
 int quiescence(int alpha, int beta, ThreadData *t, my_time* time, SearchStack *ss) {
     board *position = &t->pos;
@@ -773,8 +777,7 @@ int quiescence(int alpha, int beta, ThreadData *t, my_time* time, SearchStack *s
         if ((tt_flag == hashFlagExact) ||
             ((tt_flag == hashFlagBeta) && (tt_score <= alpha)) ||
             ((tt_flag == hashFlagAlpha) && (tt_score >= beta))) {
-             return tt_score >= beta ? (tt_score * 3 + beta) / 4 :
-                                          tt_score;
+                return get_tt_cutoff_score(tt_score, beta);
         }
     }
 
@@ -986,8 +989,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             if ((tt_flag == hashFlagExact) ||
                 ((tt_flag == hashFlagBeta) && (tt_score <= alpha)) ||
                 ((tt_flag == hashFlagAlpha) && (tt_score >= beta))) {
-                return tt_score >= beta ? (tt_score * 3 + beta) / 4 :
-                                          tt_score;
+                    return get_tt_cutoff_score(tt_score, beta);
             }
         }
     }

--- a/src/uci.c
+++ b/src/uci.c
@@ -20,7 +20,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.49.96"
+#define VERSION "3.49.97"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -0.75 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-7.50, 0.00]
Games | N: 18870 W: 5250 L: 5291 D: 8329
Penta | [405, 2085, 4453, 2130, 362]
```
https://rektdie.pythonanywhere.com/test/5149/


bench: 21154096