### PR TITLE
do quad margin for bad noisy fp and do more deeper

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1357,8 +1357,11 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             } 
 
             else {
-                int noisy_futility_margin = static_eval + BNFP_MARGIN * depth;
-                if (!in_check && depth <= 4 && mp.CURRENT_STAGE == STAGE_BAD_NOISY && noisy_futility_margin <= alpha) {
+                int sdepth = myMAX(0, depth - 4);
+                int noisy_futility_margin = static_eval + BNFP_MARGIN * depth +
+                    sdepth * sdepth * 50;
+
+                if (!in_check && depth <= 8 && mp.CURRENT_STAGE == STAGE_BAD_NOISY && noisy_futility_margin <= alpha) {
                     if (!is_decisive(bestScore) && bestScore < noisy_futility_margin) {
                         bestScore = noisy_futility_margin;
                     }

--- a/src/uci.c
+++ b/src/uci.c
@@ -20,7 +20,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "3.49.97"
+#define VERSION "3.49.98"
 #define BENCH_DEPTH 14
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 1.61 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.17 (-2.94, 2.94) [0.00, 5.00]
Games | N: 80814 W: 22920 L: 22546 D: 35348
Penta | [1894, 9610, 17063, 9908, 1932]
```
https://rektdie.pythonanywhere.com/test/5153/

```
Elo   | 2.81 +- 2.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 31144 W: 8098 L: 7846 D: 15200
Penta | [359, 3702, 7231, 3888, 392]
```
https://rektdie.pythonanywhere.com/test/5154/


bench: 19310268