### PR TITLE
second version of the 64hl, +140-147m pos + 160 superbatches

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -24,7 +24,7 @@ endif
 CFLAGS += -DCOMMIT_SHA=$(COMMIT_SHA)
 NAME        := Potential
 # Fetch the latest .bin release URL using standard shell tools (curl, grep, cut)
-LATEST_URL := $(shell curl -s https://api.github.com/repos/ProgramciDusunur/Potential-nets/releases/tags/64hl | grep "browser_download_url.*\.bin" | head -n 1 | cut -d '"' -f 4)
+LATEST_URL := $(shell curl -s https://api.github.com/repos/ProgramciDusunur/Potential-nets/releases/tags/64hl-2 | grep "browser_download_url.*\.bin" | head -n 1 | cut -d '"' -f 4)
 LATEST_BIN := $(notdir $(LATEST_URL))
 
 # Fallback in case of API rate limit or offline

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.5.4"
+#define VERSION "4.6.4"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 54.95 +- 17.54 (95%)
SPRT  | N=5000 Threads=1 Hash=32MB
LLR   | 5.74 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1256 W: 651 L: 454 D: 151
Penta | [69, 56, 269, 77, 157]
```
https://chess.erenaraz.com/test/27/

```
Elo   | 43.96 +- 18.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 10.00]
Games | N: 580 W: 221 L: 148 D: 211
Penta | [6, 46, 129, 87, 22]
```
https://chess.erenaraz.com/test/28/

```
Elo   | 48.85 +- 18.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 10.00]
Games | N: 494 W: 184 L: 115 D: 195
Penta | [3, 36, 112, 81, 15]
```
https://chess.erenaraz.com/test/29/

bench: 8389765