### PR TITLE
do material scaling

### DIFF
--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -562,13 +562,13 @@ int get_material_phase(const board* pos) {
     int rooks = countBits(pos->bitboards[R]) + countBits(pos->bitboards[r]);
     int queens = countBits(pos->bitboards[Q]) + countBits(pos->bitboards[q]);
     
-    return 100 * pawns + 300 * knights + 330 * bishops + 500 * rooks + 900 * queens;
+    return 100 * pawns + 300 * knights + 300 * bishops + 500 * rooks + 900 * queens;
 }
 
 int evaluate(board* position) {
     int eval = nnue_evaluate_pos(position);
     int phase = get_material_phase(position);
-    return eval * (14600 + phase) / 32768;
+    return eval * (25000 + phase) / 32768;
 }
 
 

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -555,8 +555,20 @@ Score get_psqt_score(const board* position) {
     return score;   
 }
 
+int get_material_phase(const board* pos) {
+    int pawns = countBits(pos->bitboards[P]) + countBits(pos->bitboards[p]);
+    int knights = countBits(pos->bitboards[N]) + countBits(pos->bitboards[n]);
+    int bishops = countBits(pos->bitboards[B]) + countBits(pos->bitboards[b]);
+    int rooks = countBits(pos->bitboards[R]) + countBits(pos->bitboards[r]);
+    int queens = countBits(pos->bitboards[Q]) + countBits(pos->bitboards[q]);
+    
+    return 100 * pawns + 300 * knights + 330 * bishops + 500 * rooks + 900 * queens;
+}
+
 int evaluate(board* position) {
-    return nnue_evaluate_pos(position);
+    int eval = nnue_evaluate_pos(position);
+    int phase = get_material_phase(position);
+    return eval * (14600 + phase) / 32768;
 }
 
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.7.5"
+#define VERSION "4.8.5"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 5.27 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11330 W: 3147 L: 2975 D: 5208
Penta | [150, 1286, 2607, 1486, 136]
```
https://chess.erenaraz.com/test/43/

```
Elo   | 8.35 +- 5.73 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 7.50]
Games | N: 4078 W: 1075 L: 977 D: 2026
Penta | [23, 452, 988, 556, 20]
```
https://chess.erenaraz.com/test/44/

bench: 7690206