### PR TITLE
add output buckets

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -24,7 +24,7 @@ endif
 CFLAGS += -DCOMMIT_SHA=$(COMMIT_SHA)
 NAME        := Potential
 # Fetch the latest .bin release URL using standard shell tools (curl, grep, cut)
-LATEST_URL := $(shell curl -s https://api.github.com/repos/ProgramciDusunur/Potential-nets/releases/tags/64hl-3 | grep "browser_download_url.*\.bin" | head -n 1 | cut -d '"' -f 4)
+LATEST_URL := $(shell curl -s https://api.github.com/repos/ProgramciDusunur/Potential-nets/releases/tags/64hl-4 | grep "browser_download_url.*\.bin" | head -n 1 | cut -d '"' -f 4)
 LATEST_BIN := $(notdir $(LATEST_URL))
 
 # Fallback in case of API rate limit or offline

--- a/src/nnue.c
+++ b/src/nnue.c
@@ -13,10 +13,12 @@ INCBIN(Net, STR(EVALFILE));
 #define QB 64
 #define SCALE 315
 
+#define OUTPUT_BUCKETS 8
+
 #define FT_SIZE (768 * HIDDEN_SIZE * 2)
 #define FB_SIZE (HIDDEN_SIZE * 2)
-#define OW_SIZE (2 * HIDDEN_SIZE * 2)
-#define OB_SIZE 2
+#define OW_SIZE (2 * HIDDEN_SIZE * 2 * OUTPUT_BUCKETS)
+#define OB_SIZE (2 * OUTPUT_BUCKETS)
 #define EXPECTED_NET_SIZE (FT_SIZE + FB_SIZE + OW_SIZE + OB_SIZE)
 
 const int16_t *feature_weights;
@@ -51,18 +53,22 @@ int nnue_evaluate_pos(board *pos) {
     int32_t sum = 0;
     int16_t *accum_stm  = (pos->side == white) ? pos->accum_white : pos->accum_black;
     int16_t *accum_nstm = (pos->side == white) ? pos->accum_black : pos->accum_white;
+
+    int piece_count = countBits(pos->occupancies[both]);
+    int bucket = (piece_count - 2) / 4;
+    int offset = bucket * 2 * HIDDEN_SIZE;
     
     for (int i = 0; i < HIDDEN_SIZE; i++) {
         int act_stm = clamp_255(accum_stm[i]);
         act_stm *= act_stm;
-        sum += act_stm * output_weights[i];
+        sum += act_stm * output_weights[i + offset];
         
         int act_nstm = clamp_255(accum_nstm[i]);
         act_nstm *= act_nstm;
-        sum += act_nstm * output_weights[i + HIDDEN_SIZE];
+        sum += act_nstm * output_weights[i + HIDDEN_SIZE + offset];
     }
     
-    int32_t out = (sum / QA) + output_bias[0];
+    int32_t out = (sum / QA) + output_bias[bucket];
     int final_eval = (int)((out * SCALE) / (QA * QB));
     
     return final_eval;

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.8.5"
+#define VERSION "4.10.5"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 8.36 +- 6.30 (95%)
SPRT  | N=5000 Threads=1 Hash=32MB
LLR   | 3.27 (-2.94, 2.94) [0.00, 7.50]
Games | N: 9564 W: 4237 L: 4007 D: 1320
Penta | [782, 561, 1970, 583, 886]
```
https://chess.erenaraz.com/test/48/

```
Elo   | 13.42 +- 8.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 10.00]
Games | N: 2020 W: 588 L: 510 D: 922
Penta | [19, 210, 483, 270, 28]
```
https://chess.erenaraz.com/test/49/

```
Elo   | 15.78 +- 9.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 10.00]
Games | N: 1498 W: 439 L: 371 D: 688
Penta | [8, 153, 364, 211, 13]
```
https://chess.erenaraz.com/test/50/


bench: 10922374