### PR TITLE
regen the whole data 5m games with the very first 128hl net

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -24,7 +24,7 @@ endif
 CFLAGS += -DCOMMIT_SHA=$(COMMIT_SHA)
 NAME        := Potential
 # Fetch the latest .bin release URL using standard shell tools (curl, grep, cut)
-LATEST_URL := $(shell curl -s https://api.github.com/repos/ProgramciDusunur/Potential-nets/releases/tags/128hl | grep "browser_download_url.*\.bin" | head -n 1 | cut -d '"' -f 4)
+LATEST_URL := $(shell curl -s https://api.github.com/repos/ProgramciDusunur/Potential-nets/releases/tags/128hl-2 | grep "browser_download_url.*\.bin" | head -n 1 | cut -d '"' -f 4)
 LATEST_BIN := $(notdir $(LATEST_URL))
 
 # Fallback in case of API rate limit or offline

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.11.5"
+#define VERSION "4.12.5"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 13.54 +- 10.34 (95%)
SPRT  | N=5000 Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 10.00]
Games | N: 3620 W: 1616 L: 1475 D: 529
Penta | [278, 243, 708, 222, 359]

Elo   | 27.81 +- 13.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 10.00]
Games | N: 864 W: 263 L: 194 D: 407
Penta | [5, 83, 197, 132, 15]

Elo   | 23.08 +- 11.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.18 (-2.94, 2.94) [0.00, 10.00]
Games | N: 980 W: 289 L: 224 D: 467
Penta | [2, 89, 248, 144, 7]
```

https://chess.erenaraz.com/test/62/
https://chess.erenaraz.com/test/63/
https://chess.erenaraz.com/test/64/

bench: 8073219