### PR TITLE
do failfirm for best score in negamax

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1780,6 +1780,10 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
             return get_draw_score(t);
     }
 
+    if (bestScore >= beta && abs(bestScore) < mateFound && abs(alpha) < mateFound) {
+        bestScore = (bestScore * (depth + 4) + beta) / (depth + 5);
+    }
+
     if (!ss->singular_move) {
         uint8_t hashFlag = hashFlagExact;
         if (alpha >= beta) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.13.6"
+#define VERSION "4.13.7"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 15.48 +- 7.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2920 W: 817 L: 687 D: 1416
Penta | [23, 308, 685, 404, 40]

Elo   | 13.11 +- 7.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 7.50]
Games | N: 2254 W: 628 L: 543 D: 1083
Penta | [5, 240, 556, 317, 9]
```
https://chess.erenaraz.com/test/77/
https://chess.erenaraz.com/test/78/

bench: 8531668