### PR TITLE
decrease the weight of the correction histories in the adjustment

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -173,7 +173,7 @@ static inline void apply_corrhist_update(int16_t *entry, const int scaledDiff, c
 
 void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * PAWN_CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
     
     // Masking for faster indexing (assuming SIZE is power of 2)
     int16_t *entry = &t->shared_history->pawn_corrhist[t->pos.side][t->pos.pawnKey & t->shared_history->corrhist_mask];
@@ -182,7 +182,7 @@ void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff)
 
 void update_minor_correction_hist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * MINOR_CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
     
     int16_t *entry = &t->shared_history->minor_corrhist[t->pos.side][t->pos.minorKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight, MINOR_CORRHIST_WEIGHT_SCALE);
@@ -190,7 +190,7 @@ void update_minor_correction_hist(ThreadData *t, const int depth, const int diff
 
 void update_major_correction_hist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * MAJOR_CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
     
     int16_t *entry = &t->shared_history->major_corrhist[t->pos.side][t->pos.majorKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight, MAJOR_CORRHIST_WEIGHT_SCALE);
@@ -199,7 +199,7 @@ void update_major_correction_hist(ThreadData *t, const int depth, const int diff
 void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff) {    
     const int side = t->pos.side;
     const int scaledDiff = diff * NON_PAWN_CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
     const int mask = t->shared_history->corrhist_mask;
     
     int16_t *white_ptr = &t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
@@ -211,7 +211,7 @@ void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff) {
 
 void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * KRP_CORRHIST_GRAIN;
-    const int newWeight = 2 * myMIN(depth + 1, 16);
+    const int newWeight = 4 * myMIN(depth + 1, 16);
     
     int16_t *entry = &t->shared_history->krp_corrhist[t->pos.side][t->pos.krpKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight, KRP_CORRHIST_WEIGHT_SCALE);
@@ -284,7 +284,7 @@ int adjust_eval_with_corrhist(ThreadData *t, int rawEval, SearchStack *ss) {
 
     const int mateFound = mateValue - maxPly;
     
-    rawEval += adjust / 256;
+    rawEval += adjust / 384;
     
     if (rawEval >= mateFound) return mateFound - 1;
     if (rawEval <= -mateFound) return -mateFound + 1;

--- a/src/history.c
+++ b/src/history.c
@@ -173,7 +173,7 @@ static inline void apply_corrhist_update(int16_t *entry, const int scaledDiff, c
 
 void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * PAWN_CORRHIST_GRAIN;
-    const int newWeight = 4 * myMIN(depth + 1, 16);
+    const int newWeight = 2 * myMIN(depth + 1, 16);
     
     // Masking for faster indexing (assuming SIZE is power of 2)
     int16_t *entry = &t->shared_history->pawn_corrhist[t->pos.side][t->pos.pawnKey & t->shared_history->corrhist_mask];
@@ -182,7 +182,7 @@ void update_pawn_correction_hist(ThreadData *t, const int depth, const int diff)
 
 void update_minor_correction_hist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * MINOR_CORRHIST_GRAIN;
-    const int newWeight = 4 * myMIN(depth + 1, 16);
+    const int newWeight = 2 * myMIN(depth + 1, 16);
     
     int16_t *entry = &t->shared_history->minor_corrhist[t->pos.side][t->pos.minorKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight, MINOR_CORRHIST_WEIGHT_SCALE);
@@ -190,7 +190,7 @@ void update_minor_correction_hist(ThreadData *t, const int depth, const int diff
 
 void update_major_correction_hist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * MAJOR_CORRHIST_GRAIN;
-    const int newWeight = 4 * myMIN(depth + 1, 16);
+    const int newWeight = 2 * myMIN(depth + 1, 16);
     
     int16_t *entry = &t->shared_history->major_corrhist[t->pos.side][t->pos.majorKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight, MAJOR_CORRHIST_WEIGHT_SCALE);
@@ -199,7 +199,7 @@ void update_major_correction_hist(ThreadData *t, const int depth, const int diff
 void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff) {    
     const int side = t->pos.side;
     const int scaledDiff = diff * NON_PAWN_CORRHIST_GRAIN;
-    const int newWeight = 4 * myMIN(depth + 1, 16);
+    const int newWeight = 2 * myMIN(depth + 1, 16);
     const int mask = t->shared_history->corrhist_mask;
     
     int16_t *white_ptr = &t->shared_history->non_pawn_corrhist[white][side][t->pos.whiteNonPawnKey & mask];
@@ -211,7 +211,7 @@ void update_non_pawn_corrhist(ThreadData *t, const int depth, const int diff) {
 
 void update_king_rook_pawn_corrhist(ThreadData *t, const int depth, const int diff) {
     const int scaledDiff = diff * KRP_CORRHIST_GRAIN;
-    const int newWeight = 4 * myMIN(depth + 1, 16);
+    const int newWeight = 2 * myMIN(depth + 1, 16);
     
     int16_t *entry = &t->shared_history->krp_corrhist[t->pos.side][t->pos.krpKey & t->shared_history->corrhist_mask];
     apply_corrhist_update(entry, scaledDiff, newWeight, KRP_CORRHIST_WEIGHT_SCALE);

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,7 +21,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.13.7"
+#define VERSION "4.13.8"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 18.75 +- 8.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2022 W: 593 L: 484 D: 945
Penta | [16, 199, 485, 282, 29]
```
https://chess.erenaraz.com/test/89/

```
Elo   | 17.49 +- 8.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2008 W: 545 L: 444 D: 1019
Penta | [6, 203, 488, 298, 9]
```
https://chess.erenaraz.com/test/90/

bench: 8213712