### PR TITLE
second 1024hl that comes 15m games from the very first 1024hl

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -24,8 +24,8 @@ endif
 CFLAGS += -DCOMMIT_SHA=$(COMMIT_SHA)
 NAME        := Potential
 
-NET_TAG  := 1024hl-2
-NET      := potential-1024hl-480sb.bin
+NET_TAG  := 1024hl-3
+NET      := potential-1024hl-3.bin
 NET_URL  := https://github.com/ProgramciDusunur/Potential-nets/releases/download/$(NET_TAG)/$(NET)
 EVALFILE ?= $(NET)
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -22,7 +22,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.21.13"
+#define VERSION "4.22.13"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | -7.68 +- 7.18 (95%)
SPRT  | N=5000 Threads=1 Hash=8MB
LLR   | -3.16 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6700 W: 2695 L: 2843 D: 1162
Penta | [532, 490, 1403, 444, 481]

Elo   | 4.50 +- 3.55 (95%)
SPRT  | N=20000 Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22922 W: 8485 L: 8188 D: 6249
Penta | [1181, 2204, 4473, 2343, 1260]

Elo   | 5.99 +- 4.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9392 W: 2706 L: 2544 D: 4142
Penta | [122, 1055, 2180, 1217, 122]

Elo   | 10.91 +- 5.74 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3950 W: 1099 L: 975 D: 1876
Penta | [13, 438, 953, 554, 17]
```
https://chess.erenaraz.com/test/229/
https://chess.erenaraz.com/test/228/
https://chess.erenaraz.com/test/230/ 
https://chess.erenaraz.com/test/231/

bench: 7467555