### PR TITLE
do failfirm in reverse futility pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1092,7 +1092,7 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
     if (!ss->singular_move && rfp_tt_pv_decision &&
         depth <= RFP_DEPTH && !pvNode && !in_check && (!tt_hit || ttAdjustedEval != static_eval) &&
         ttAdjustedEval - rfpMargin >= beta + (corrplexity * RFP_CORRPLEXITY_MULT) / RFP_CORRPLEXITY_DIVISOR)
-        return ttAdjustedEval;
+        return (ttAdjustedEval + beta) / 2;
 
     // Null Move Pruning
     if (!ss->singular_move && depth >= NMP_DEPTH && !in_check && !rootNode &&

--- a/src/uci.c
+++ b/src/uci.c
@@ -22,7 +22,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.23.13"
+#define VERSION "4.23.14"
 #define BENCH_DEPTH 13
 #define MAX_THREADS 512
 


### PR DESCRIPTION
```
Elo   | 16.15 +- 7.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2734 W: 760 L: 633 D: 1341
Penta | [21, 273, 659, 386, 28]

Elo   | 14.78 +- 6.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2634 W: 698 L: 586 D: 1350
Penta | [2, 254, 698, 356, 7]
```
https://chess.erenaraz.com/test/239/
https://chess.erenaraz.com/test/241/



bench: 7978380