### PR TITLE
simplify razoring

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -188,10 +188,6 @@
   /*╔══════════╗
     ║ Razoring ║
     ╚══════════╝*/
-  TUNE_INT RAZORING_DEPTH = 3;
-  TUNE_INT RAZORING_FULL_MARGIN = 202;    
-  TUNE_INT RAZORING_VERIFY_MARGIN = 124;
-  
   extern TUNE_DOUBLE TM_BEST_MOVE_SCALE_0;
   extern TUNE_DOUBLE TM_BEST_MOVE_SCALE_1;
   extern TUNE_DOUBLE TM_BEST_MOVE_SCALE_2;
@@ -208,11 +204,7 @@
   extern TUNE_DOUBLE TM_NODE_FRACTION_BASE;
   extern TUNE_DOUBLE TM_NODE_MULTIPLIER;
   extern TUNE_DOUBLE TM_NODE_MIN_MULTIPLIER;
-  TUNE_INT RAZORING_TRIM = 1;
-  TUNE_INT RAZORING_FULL_D = 2;
-  TUNE_INT RAZORING_VERIFY_D = 3;
-  TUNE_INT RAZORING_MARGIN = 115;
-  
+  TUNE_INT RAZORING_ALPHA_REDUCTION = 300;
   
   /*╔═════════════════════╗
     ║ Singular Extensions ║
@@ -1193,30 +1185,8 @@ int negamax(int alpha, int beta, int depth, ThreadData *t, my_time* time, Search
     }
 
     // razoring
-    const int razoring_margin = RAZORING_MARGIN * depth;
-    if (!ss->singular_move && !pvNode && !in_check && depth <= RAZORING_DEPTH && ttAdjustedEval + razoring_margin <= alpha && tt_flag != hashFlagAlpha) {
-        
-        const bool allow_full_razor = depth == 1 ||
-            (depth <= RAZORING_FULL_D && ttAdjustedEval + razoring_margin + RAZORING_FULL_MARGIN <= alpha);
-
-        if (allow_full_razor) {
-            return quiescence(alpha, beta, t, time, ss);
-        }
-
-        const int capped_alpha = myMAX(alpha - razoring_margin, -mateValue);
-        const int razor_alpha = capped_alpha;
-        const int razor_beta = razor_alpha + 1;
-        int razor_score = quiescence(razor_alpha, razor_beta, t, time, ss);
-
-        // We proved a fail low.
-        if (razor_score <= razor_alpha) {                       
-            return razor_score;
-        }
-
-        if (razor_score >= razor_beta + RAZORING_VERIFY_MARGIN && depth <= RAZORING_VERIFY_D) {                    
-            depth -= myMIN(RAZORING_TRIM, depth - 1);
-        }
-    }
+    if (!ss->singular_move && !pvNode && !in_check && ttAdjustedEval <= alpha - RAZORING_ALPHA_REDUCTION * depth * depth && tt_flag != hashFlagAlpha)
+        return quiescence(alpha, beta, t, time, ss);
 
     // moves seen counter
     int moves_seen = 0;

--- a/src/uci.c
+++ b/src/uci.c
@@ -22,7 +22,7 @@ extern _Atomic uint64_t total_fens_generated;
 extern _Atomic uint64_t games_played_count;
 extern uint64_t global_start_time;
 
-#define VERSION "4.26.15"
+#define VERSION "4.27.15"
 #define BENCH_DEPTH 11
 #define MAX_THREADS 512
 


### PR DESCRIPTION
This patch simplfies razoring

Passed non-reg STC:
Elo   | 3.13 +- 4.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 8780 W: 2313 L: 2234 D: 4233
Penta | [64, 1040, 2112, 1101, 73]

https://chess.erenaraz.com/test/266/

Passed non-reg VLTC:
Elo   | 3.12 +- 3.76 (95%)
SPRT  | 80.0+0.80s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 8122 W: 1970 L: 1897 D: 4255
Penta | [8, 934, 2109, 997, 13]

https://chess.erenaraz.com/test/281/

Bench: 3211928